### PR TITLE
Implement RFC4880bis-04

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,22 @@ OpenPGP.js [![Build Status](https://travis-ci.org/openpgpjs/openpgpjs.svg?branch
 
 * If the user's browser supports [native WebCrypto](https://caniuse.com/#feat=cryptography) via the `window.crypto.subtle` API, this will be used. Under Node.js the native [crypto module](https://nodejs.org/API/crypto.html#crypto_crypto) is used. This can be deactivated by setting `openpgp.config.use_native = false`.
 
-* The library implements the [IETF proposal](https://tools.ietf.org/html/draft-ford-openpgp-format-00) for authenticated encryption [using native AES-GCM](https://github.com/openpgpjs/openpgpjs/pull/430). This makes symmetric encryption about 30x faster on supported platforms. Since the specification has not been finalized and other OpenPGP implementations haven't adopted it yet, the feature is currently behind a flag. You can activate it by setting `openpgp.config.aead_protect = true`. **Note: activating this setting can break compatibility with other OpenPGP implementations, so be careful if that's one of your requirements.**
+* The library implements the [IETF proposal](https://tools.ietf.org/html/draft-ietf-openpgp-rfc4880bis-04) for authenticated encryption using native AES-EAX, OCB, or GCM. This makes symmetric encryption up to 30x faster on supported platforms. Since the specification has not been finalized and other OpenPGP implementations haven't adopted it yet, the feature is currently behind a flag. **Note: activating this setting can break compatibility with other OpenPGP implementations, and also with future versions of OpenPGP.js. Don't use it with messages you want to store on disk or in a database.** You can enable it by setting:
+
+  ```
+  openpgp.config.aead_protect = true
+  openpgp.config.aead_protect_version = 4
+  ```
+
+  You can change the AEAD mode by setting one of the following options:
+
+  ```
+  openpgp.config.aead_mode = openpgp.enums.aead.eax // Default, native
+  openpgp.config.aead_mode = openpgp.enums.aead.ocb // Non-native
+  openpgp.config.aead_mode = openpgp.enums.aead.gcm // **Non-standard**, fastest
+  ```
+
+  We previously also implemented an [earlier version](https://tools.ietf.org/html/draft-ford-openpgp-format-00) of the draft (using GCM), which you could enable by simply setting `openpgp.config.aead_protect = true`. If you need to stay compatible with that version, don't set `openpgp.config.aead_protect_version = 4`.
 
 * For environments that don't provide native crypto, the library falls back to [asm.js](https://caniuse.com/#feat=asmjs) implementations of AES, SHA-1, and SHA-256. We use [Rusha](https://github.com/srijs/rusha) and [asmCrypto Lite](https://github.com/openpgpjs/asmcrypto-lite) (a minimal subset of asmCrypto.js built specifically for OpenPGP.js).
 
@@ -92,8 +107,6 @@ Here are some examples of how to use the v2.x+ API. For more elaborate examples 
 var openpgp = require('openpgp'); // use as CommonJS, AMD, ES6 module or via window.openpgp
 
 openpgp.initWorker({ path:'openpgp.worker.js' }) // set the relative web worker path
-
-openpgp.config.aead_protect = true // activate fast AES-GCM mode (not yet OpenPGP standard)
 ```
 
 #### Encrypt and decrypt *Uint8Array* data with a password

--- a/README.md
+++ b/README.md
@@ -54,11 +54,11 @@ OpenPGP.js [![Build Status](https://travis-ci.org/openpgpjs/openpgpjs.svg?branch
     | p384            | ECDH       | ECDSA     | Yes      | Yes*       | Yes*      |
     | p521            | ECDH       | ECDSA     | Yes      | Yes*       | Yes*      |
     | secp256k1       | ECDH       | ECDSA     | Yes      | Yes*       | No        |
-    | curve25519      | ECDH       | N/A       | Yes      | No (TODO)  | No        |
-    | ed25519         | N/A        | EdDSA     | Yes      | No (TODO)  | No        |
-    | brainpoolP256r1 | ECDH       | ECDSA     | Yes      | No (TODO)  | No        |
-    | brainpoolP384r1 | ECDH       | ECDSA     | Yes      | No (TODO)  | No        |
-    | brainpoolP512r1 | ECDH       | ECDSA     | Yes      | No (TODO)  | No        |
+    | brainpoolP256r1 | ECDH       | ECDSA     | Yes      | Yes*       | No        |
+    | brainpoolP384r1 | ECDH       | ECDSA     | Yes      | Yes*       | No        |
+    | brainpoolP512r1 | ECDH       | ECDSA     | Yes      | Yes*       | No        |
+    | curve25519      | ECDH       | N/A       | Yes      | No         | No        |
+    | ed25519         | N/A        | EdDSA     | Yes      | No         | No        |
 
 * Version 2.x of the library has been built from the ground up with Uint8Arrays. This allows for much better performance and memory usage than strings.
 

--- a/src/cleartext.js
+++ b/src/cleartext.js
@@ -19,6 +19,7 @@
  * @requires config
  * @requires encoding/armor
  * @requires enums
+ * @requires util
  * @requires packet
  * @requires signature
  * @module cleartext
@@ -27,6 +28,7 @@
 import config from './config';
 import armor from './encoding/armor';
 import enums from './enums';
+import util from './util';
 import packet from './packet';
 import { Signature } from './signature';
 import { createVerificationObjects, createSignaturePackets } from './message';
@@ -43,7 +45,7 @@ export function CleartextMessage(text, signature) {
     return new CleartextMessage(text, signature);
   }
   // normalize EOL to canonical form <CR><LF>
-  this.text = text.replace(/\r\n/g, "\n").replace(/\r/g, "\n").replace(/[ \t]+\n/g, "\n").replace(/\n/g, "\r\n");
+  this.text = util.canonicalizeEOL(util.removeTrailingSpaces(text));
   if (signature && !(signature instanceof Signature)) {
     throw new Error('Invalid signature input');
   }
@@ -122,7 +124,7 @@ CleartextMessage.prototype.verifyDetached = function(signature, keys, date=new D
  */
 CleartextMessage.prototype.getText = function() {
   // normalize end of line to \n
-  return this.text.replace(/\r\n/g, "\n");
+  return util.nativeEOL(this.text);
 };
 
 /**

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -59,6 +59,13 @@ export default {
    * @property {Integer} aead_chunk_size_byte
    */
   aead_chunk_size_byte:     46,
+  /**
+   * {@link https://tools.ietf.org/html/rfc4880#section-3.7.1.3|RFC4880 3.7.1.3}:
+   * Iteration Count Byte for S2K (String to Key)
+   * @memberof module:config
+   * @property {Integer} s2k_iteration_count_byte
+   */
+  s2k_iteration_count_byte: 96,
   /** Use integrity protection for symmetric encryption
    * @memberof module:config
    * @property {Boolean} integrity_protect

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -63,6 +63,7 @@ export default {
   /**
    * Default Authenticated Encryption with Additional Data (AEAD) encryption mode
    * Only has an effect when aead_protect is set to true.
+   * **FUTURE OPENPGP.JS VERSIONS MAY BREAK COMPATIBILITY WHEN USING THIS OPTION**
    * @memberof module:config
    * @property {Integer} aead_mode Default AEAD mode {@link module:enums.aead}
    */

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -52,6 +52,15 @@ export default {
    */
   aead_protect:             false,
   /**
+   * Use Authenticated Encryption with Additional Data (AEAD) protection for symmetric encryption.
+   * 0 means we implement a variant of {@link https://tools.ietf.org/html/draft-ford-openpgp-format-00|this IETF draft}.
+   * 4 means we implement {@link https://tools.ietf.org/html/draft-ietf-openpgp-rfc4880bis-04|RFC4880bis-04}.
+   * Only has an effect when aead_protect is set to true.
+   * @memberof module:config
+   * @property {Integer} aead_protect_version
+   */
+  aead_protect_version:     0,
+  /**
    * Default Authenticated Encryption with Additional Data (AEAD) encryption mode
    * Only has an effect when aead_protect is set to true.
    * @memberof module:config

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -52,6 +52,13 @@ export default {
    */
   aead_protect:             false,
   /**
+   * Default Authenticated Encryption with Additional Data (AEAD) encryption mode
+   * Only has an effect when aead_protect is set to true.
+   * @memberof module:config
+   * @property {Integer} aead_mode Default AEAD mode {@link module:enums.aead}
+   */
+  aead_mode: enums.aead.eax,
+  /**
    * Chunk Size Byte for Authenticated Encryption with Additional Data (AEAD) mode
    * Only has an effect when aead_protect is set to true.
    * Must be an integer value from 0 to 56.

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -51,6 +51,14 @@ export default {
    * @property {Boolean} aead_protect
    */
   aead_protect:             false,
+  /**
+   * Chunk Size Byte for Authenticated Encryption with Additional Data (AEAD) mode
+   * Only has an effect when aead_protect is set to true.
+   * Must be an integer value from 0 to 56.
+   * @memberof module:config
+   * @property {Integer} aead_chunk_size_byte
+   */
+  aead_chunk_size_byte:     46,
   /** Use integrity protection for symmetric encryption
    * @memberof module:config
    * @property {Boolean} integrity_protect

--- a/src/crypto/cipher/aes.js
+++ b/src/crypto/cipher/aes.js
@@ -2,19 +2,20 @@
  * @requires asmcrypto.js
  */
 
-import { AES_ECB } from 'asmcrypto.js/src/aes/ecb/exports';
+import { _AES_asm_instance, _AES_heap_instance } from 'asmcrypto.js/src/aes/exports';
+import { AES_ECB } from 'asmcrypto.js/src/aes/ecb/ecb';
 
 // TODO use webCrypto or nodeCrypto when possible.
 function aes(length) {
   const c = function(key) {
-    this.key = key;
+    const aes_ecb = new AES_ECB(key, _AES_heap_instance, _AES_asm_instance);
 
     this.encrypt = function(block) {
-      return AES_ECB.encrypt(block, this.key, false);
+      return aes_ecb.encrypt(block).result;
     };
 
     this.decrypt = function(block) {
-      return AES_ECB.decrypt(block, this.key, false);
+      return aes_ecb.decrypt(block).result;
     };
   };
 

--- a/src/crypto/cipher/aes.js
+++ b/src/crypto/cipher/aes.js
@@ -7,16 +7,14 @@ import { AES_ECB } from 'asmcrypto.js/src/aes/ecb/exports';
 // TODO use webCrypto or nodeCrypto when possible.
 function aes(length) {
   const c = function(key) {
-    this.key = Uint8Array.from(key);
+    this.key = key;
 
     this.encrypt = function(block) {
-      block = Uint8Array.from(block);
-      return Array.from(AES_ECB.encrypt(block, this.key, false));
+      return AES_ECB.encrypt(block, this.key, false);
     };
 
     this.decrypt = function(block) {
-      block = Uint8Array.from(block);
-      return Array.from(AES_ECB.decrypt(block, this.key, false));
+      return AES_ECB.decrypt(block, this.key, false);
     };
   };
 

--- a/src/crypto/cmac.js
+++ b/src/crypto/cmac.js
@@ -1,0 +1,21 @@
+/**
+ * @requires asmcrypto.js
+ */
+
+import { AES_CMAC } from 'asmcrypto.js/src/aes/cmac/cmac';
+
+export default class CMAC extends AES_CMAC {
+  constructor(key) {
+    super(key);
+    this._k = this.k.slice();
+  }
+
+  mac(data) {
+    if (this.result) {
+      this.bufferLength = 0;
+      this.k.set(this._k, 0);
+      this.cbc.AES_reset(undefined, new Uint8Array(16), false);
+    }
+    return this.process(data).finish().result;
+  }
+}

--- a/src/crypto/cmac.js
+++ b/src/crypto/cmac.js
@@ -1,21 +1,80 @@
 /**
+ * @fileoverview This module implements AES-CMAC on top of
+ * native AES-CBC using either the WebCrypto API or Node.js' crypto API.
  * @requires asmcrypto.js
+ * @requires util
+ * @module crypto/cmac
  */
 
-import { AES_CMAC } from 'asmcrypto.js/src/aes/cmac/cmac';
+import { AES_CBC } from 'asmcrypto.js/src/aes/cbc/exports';
+import util from '../util';
 
-export default class CMAC extends AES_CMAC {
-  constructor(key) {
-    super(key);
-    this._k = this.k.slice();
-  }
+const webCrypto = util.getWebCryptoAll();
+const nodeCrypto = util.getNodeCrypto();
+const Buffer = util.getNodeBuffer();
 
-  mac(data) {
-    if (this.result) {
-      this.bufferLength = 0;
-      this.k.set(this._k, 0);
-      this.cbc.AES_reset(undefined, new Uint8Array(16), false);
-    }
-    return this.process(data).finish().result;
+
+const blockLength = 16;
+
+
+function set_xor_r(S, T) {
+  const offset = S.length - blockLength;
+  for (let i = 0; i < blockLength; i++) {
+    S[i + offset] ^= T[i];
   }
+  return S;
+}
+
+function mul2(data) {
+  const t = data[0] & 0x80;
+  for (let i = 0; i < 15; i++) {
+    data[i] = (data[i] << 1) ^ ((data[i + 1] & 0x80) ? 1 : 0);
+  }
+  data[15] = (data[15] << 1) ^ (t ? 0x87 : 0);
+  return data;
+}
+
+const zeros_16 = new Uint8Array(16);
+
+export default async function CMAC(key) {
+  const cbc = await CBC(key);
+  const padding = mul2(await cbc(zeros_16));
+  const padding2 = mul2(padding.slice());
+
+  return async function(data) {
+    return (await cbc(pad(data, padding, padding2))).subarray(-blockLength);
+  };
+}
+
+function pad(data, padding, padding2) {
+  if (data.length % blockLength === 0) {
+    return set_xor_r(data, padding);
+  }
+  const padded = new Uint8Array(data.length + (blockLength - data.length % blockLength));
+  padded.set(data);
+  padded[data.length] = 0b10000000;
+  return set_xor_r(padded, padding2);
+}
+
+async function CBC(key) {
+  if (util.getWebCryptoAll() && key.length !== 24) { // WebCrypto (no 192 bit support) see: https://www.chromium.org/blink/webcrypto#TOC-AES-support
+    key = await webCrypto.importKey('raw', key, { name: 'AES-CBC', length: key.length * 8 }, false, ['encrypt']);
+    return async function(pt) {
+      const ct = await webCrypto.encrypt({ name: 'AES-CBC', iv: zeros_16, length: blockLength * 8 }, key, pt);
+      return new Uint8Array(ct).subarray(0, ct.byteLength - blockLength);
+    };
+  }
+  if (util.getNodeCrypto()) { // Node crypto library
+    key = new Buffer(key);
+    return async function(pt) {
+      pt = new Buffer(pt);
+      const en = new nodeCrypto.createCipheriv('aes-' + (key.length * 8) + '-cbc', key, zeros_16);
+      const ct = en.update(pt);
+      return new Uint8Array(ct);
+    };
+  }
+  // asm.js fallback
+  return async function(pt) {
+    return AES_CBC.encrypt(pt, key, false, zeros_16);
+  };
 }

--- a/src/crypto/cmac.js
+++ b/src/crypto/cmac.js
@@ -14,17 +14,47 @@ const nodeCrypto = util.getNodeCrypto();
 const Buffer = util.getNodeBuffer();
 
 
+/**
+ * This implementation of CMAC is based on the description of OMAC in
+ * http://web.cs.ucdavis.edu/~rogaway/papers/eax.pdf. As per that
+ * document:
+ *
+ * We have made a small modification to the OMAC algorithm as it was
+ * originally presented, changing one of its two constants.
+ * Specifically, the constant 4 at line 85 was the constant 1/2 (the
+ * multiplicative inverse of 2) in the original definition of OMAC [14].
+ * The OMAC authors indicate that they will promulgate this modification
+ * [15], which slightly simplifies implementations.
+ */
+
 const blockLength = 16;
 
 
-function set_xor_r(S, T) {
-  const offset = S.length - blockLength;
+/**
+ * xor `padding` into the end of `data`. This function implements "the
+ * operation xor→ [which] xors the shorter string into the end of longer
+ * one". Since data is always as least as long as padding, we can
+ * simplify the implementation.
+ * @param {Uint8Array} data
+ * @param {Uint8Array} padding
+ */
+function rightXorMut(data, padding) {
+  const offset = data.length - blockLength;
   for (let i = 0; i < blockLength; i++) {
-    S[i + offset] ^= T[i];
+    data[i + offset] ^= padding[i];
   }
-  return S;
+  return data;
 }
 
+/**
+ * 2L = L<<1 if the first bit of L is 0 and 2L = (L<<1) xor (0^120 ||
+ * 10000111) otherwise, where L<<1 means the left shift of L by one
+ * position (the first bit vanishing and a zero entering into the last
+ * bit). The value of 4L is simply 2(2L). We warn that to avoid side-
+ * channel attacks one must implement the doubling operation in a
+ * constant-time manner.
+ * @param {Uint8Array} data
+ */
 function mul2(data) {
   const t = data[0] & 0x80;
   for (let i = 0; i < 15; i++) {
@@ -34,33 +64,39 @@ function mul2(data) {
   return data;
 }
 
-const zeros_16 = new Uint8Array(16);
-
-export default async function CMAC(key) {
-  const cbc = await CBC(key);
-  const padding = mul2(await cbc(zeros_16));
-  const padding2 = mul2(padding.slice());
-
-  return async function(data) {
-    return (await cbc(pad(data, padding, padding2))).subarray(-blockLength);
-  };
-}
-
 function pad(data, padding, padding2) {
+  // if |M| in {n, 2n, 3n, ...}
   if (data.length % blockLength === 0) {
-    return set_xor_r(data, padding);
+    // then return M xor→ B,
+    return rightXorMut(data, padding);
   }
+  // else return (M || 10^(n−1−(|M| mod n))) xor→ P
   const padded = new Uint8Array(data.length + (blockLength - data.length % blockLength));
   padded.set(data);
   padded[data.length] = 0b10000000;
-  return set_xor_r(padded, padding2);
+  return rightXorMut(padded, padding2);
+}
+
+const zeroBlock = new Uint8Array(blockLength);
+
+export default async function CMAC(key) {
+  const cbc = await CBC(key);
+
+  // L ← E_K(0^n); B ← 2L; P ← 4L
+  const padding = mul2(await cbc(zeroBlock));
+  const padding2 = mul2(padding.slice());
+
+  return async function(data) {
+    // return CBC_K(pad(M; B, P))
+    return (await cbc(pad(data, padding, padding2))).subarray(-blockLength);
+  };
 }
 
 async function CBC(key) {
   if (util.getWebCryptoAll() && key.length !== 24) { // WebCrypto (no 192 bit support) see: https://www.chromium.org/blink/webcrypto#TOC-AES-support
     key = await webCrypto.importKey('raw', key, { name: 'AES-CBC', length: key.length * 8 }, false, ['encrypt']);
     return async function(pt) {
-      const ct = await webCrypto.encrypt({ name: 'AES-CBC', iv: zeros_16, length: blockLength * 8 }, key, pt);
+      const ct = await webCrypto.encrypt({ name: 'AES-CBC', iv: zeroBlock, length: blockLength * 8 }, key, pt);
       return new Uint8Array(ct).subarray(0, ct.byteLength - blockLength);
     };
   }
@@ -68,13 +104,13 @@ async function CBC(key) {
     key = new Buffer(key);
     return async function(pt) {
       pt = new Buffer(pt);
-      const en = new nodeCrypto.createCipheriv('aes-' + (key.length * 8) + '-cbc', key, zeros_16);
+      const en = new nodeCrypto.createCipheriv('aes-' + (key.length * 8) + '-cbc', key, zeroBlock);
       const ct = en.update(pt);
       return new Uint8Array(ct);
     };
   }
   // asm.js fallback
   return async function(pt) {
-    return AES_CBC.encrypt(pt, key, false, zeros_16);
+    return AES_CBC.encrypt(pt, key, false, zeroBlock);
   };
 }

--- a/src/crypto/eax.js
+++ b/src/crypto/eax.js
@@ -137,9 +137,9 @@ function concat(...arrays) {
 }
 
 function CTR(plaintext, key, iv) {
-  if (webCrypto && key.length !== 24) { // WebCrypto (no 192 bit support) see: https://www.chromium.org/blink/webcrypto#TOC-AES-support
+  if (util.getWebCryptoAll() && key.length !== 24) { // WebCrypto (no 192 bit support) see: https://www.chromium.org/blink/webcrypto#TOC-AES-support
     return webCtr(plaintext, key, iv);
-  } else if (nodeCrypto) { // Node crypto library
+  } else if (util.getNodeCrypto()) { // Node crypto library
     return nodeCtr(plaintext, key, iv);
   } // asm.js fallback
   return Promise.resolve(AES_CTR.encrypt(plaintext, key, iv));

--- a/src/crypto/eax.js
+++ b/src/crypto/eax.js
@@ -47,78 +47,112 @@ class OMAC extends CMAC {
   }
 }
 
-
-/**
- * Encrypt plaintext input.
- * @param  {String}     cipher      The symmetric cipher algorithm to use e.g. 'aes128'
- * @param  {Uint8Array} plaintext   The cleartext input to be encrypted
- * @param  {Uint8Array} key         The encryption key
- * @param  {Uint8Array} nonce       The nonce (16 bytes)
- * @param  {Uint8Array} adata       Associated data to sign
- * @returns {Promise<Uint8Array>}    The ciphertext output
- */
-async function encrypt(cipher, plaintext, key, nonce, adata) {
-  if (cipher.substr(0, 3) !== 'aes') {
-    throw new Error('EAX mode supports only AES cipher');
+class CTR {
+  constructor(key) {
+    if (util.getWebCryptoAll() && key.length !== 24) { // WebCrypto (no 192 bit support) see: https://www.chromium.org/blink/webcrypto#TOC-AES-support
+      this.key = webCrypto.importKey('raw', key, { name: 'AES-CTR', length: key.length * 8 }, false, ['encrypt']);
+      this.ctr = this.webCtr;
+    } else if (util.getNodeCrypto()) { // Node crypto library
+      this.key = new Buffer(key);
+      this.ctr = this.nodeCtr;
+    } else {
+      // asm.js fallback
+      this.key = key;
+    }
   }
 
-  const omac = new OMAC(key);
-  const _nonce = omac.mac(zero, nonce);
-  const _adata = omac.mac(one, adata);
-  const ciphered = await CTR(plaintext, key, _nonce);
-  const _ciphered = omac.mac(two, ciphered);
-  const tag = xor3(_nonce, _ciphered, _adata); // Assumes that omac.mac(*).length === tagLength.
-  return concat(ciphered, tag);
-}
-
-/**
- * Decrypt ciphertext input.
- * @param  {String}     cipher       The symmetric cipher algorithm to use e.g. 'aes128'
- * @param  {Uint8Array} ciphertext   The ciphertext input to be decrypted
- * @param  {Uint8Array} key          The encryption key
- * @param  {Uint8Array} nonce        The nonce (16 bytes)
- * @param  {Uint8Array} adata        Associated data to verify
- * @returns {Promise<Uint8Array>}     The plaintext output
- */
-async function decrypt(cipher, ciphertext, key, nonce, adata) {
-  if (cipher.substr(0, 3) !== 'aes') {
-    throw new Error('EAX mode supports only AES cipher');
+  webCtr(pt, iv) {
+    return this.key
+      .then(keyObj => webCrypto.encrypt({ name: 'AES-CTR', counter: iv, length: blockLength * 8 }, keyObj, pt))
+      .then(ct => new Uint8Array(ct));
   }
 
-  if (ciphertext.length < tagLength) throw new Error('Invalid EAX ciphertext');
-  const ciphered = ciphertext.subarray(0, ciphertext.length - tagLength);
-  const tag = ciphertext.subarray(ciphertext.length - tagLength);
-  const omac = new OMAC(key);
-  const _nonce = omac.mac(zero, nonce);
-  const _adata = omac.mac(one, adata);
-  const _ciphered = omac.mac(two, ciphered);
-  const _tag = xor3(_nonce, _ciphered, _adata); // Assumes that omac.mac(*).length === tagLength.
-  if (!util.equalsUint8Array(tag, _tag)) throw new Error('Authentication tag mismatch in EAX ciphertext');
-  const plaintext = await CTR(ciphered, key, _nonce);
-  return plaintext;
+  nodeCtr(pt, iv) {
+    pt = new Buffer(pt);
+    iv = new Buffer(iv);
+    const en = new nodeCrypto.createCipheriv('aes-' + (this.key.length * 8) + '-ctr', this.key, iv);
+    const ct = Buffer.concat([en.update(pt), en.final()]);
+    return Promise.resolve(new Uint8Array(ct));
+  }
+
+  ctr(pt, iv) {
+    return Promise.resolve(AES_CTR.encrypt(pt, this.key, iv));
+  }
 }
+
+
+class EAX {
+  /**
+   * Class to en/decrypt using EAX mode.
+   * @param  {String}     cipher      The symmetric cipher algorithm to use e.g. 'aes128'
+   * @param  {Uint8Array} key         The encryption key
+   */
+  constructor(cipher, key) {
+    if (cipher.substr(0, 3) !== 'aes') {
+      throw new Error('EAX mode supports only AES cipher');
+    }
+
+    const omac = new OMAC(key);
+    this.omac = omac.mac.bind(omac);
+    const ctr = new CTR(key);
+    this.ctr = ctr.ctr.bind(ctr);
+  }
+
+  /**
+   * Encrypt plaintext input.
+   * @param  {Uint8Array} plaintext   The cleartext input to be encrypted
+   * @param  {Uint8Array} nonce       The nonce (16 bytes)
+   * @param  {Uint8Array} adata       Associated data to sign
+   * @returns {Promise<Uint8Array>}    The ciphertext output
+   */
+  async encrypt(plaintext, nonce, adata) {
+    const _nonce = this.omac(zero, nonce);
+    const _adata = this.omac(one, adata);
+    const ciphered = await this.ctr(plaintext, _nonce);
+    const _ciphered = this.omac(two, ciphered);
+    const tag = xor3(_nonce, _ciphered, _adata); // Assumes that omac(*).length === tagLength.
+    return concat(ciphered, tag);
+  }
+
+  /**
+   * Decrypt ciphertext input.
+   * @param  {Uint8Array} ciphertext   The ciphertext input to be decrypted
+   * @param  {Uint8Array} nonce        The nonce (16 bytes)
+   * @param  {Uint8Array} adata        Associated data to verify
+   * @returns {Promise<Uint8Array>}     The plaintext output
+   */
+  async decrypt(ciphertext, nonce, adata) {
+    if (ciphertext.length < tagLength) throw new Error('Invalid EAX ciphertext');
+    const ciphered = ciphertext.subarray(0, ciphertext.length - tagLength);
+    const tag = ciphertext.subarray(ciphertext.length - tagLength);
+    const _nonce = this.omac(zero, nonce);
+    const _adata = this.omac(one, adata);
+    const _ciphered = this.omac(two, ciphered);
+    const _tag = xor3(_nonce, _ciphered, _adata); // Assumes that omac(*).length === tagLength.
+    if (!util.equalsUint8Array(tag, _tag)) throw new Error('Authentication tag mismatch in EAX ciphertext');
+    const plaintext = await this.ctr(ciphered, _nonce);
+    return plaintext;
+  }
+}
+
 
 /**
  * Get EAX nonce as defined by {@link https://tools.ietf.org/html/draft-ietf-openpgp-rfc4880bis-04#section-5.16.1|RFC4880bis-04, section 5.16.1}.
  * @param  {Uint8Array} iv           The initialization vector (16 bytes)
  * @param  {Uint8Array} chunkIndex   The chunk index (8 bytes)
  */
-function getNonce(iv, chunkIndex) {
+EAX.getNonce = function(iv, chunkIndex) {
   const nonce = iv.slice();
   for (let i = 0; i < chunkIndex.length; i++) {
     nonce[8 + i] ^= chunkIndex[i];
   }
   return nonce;
-}
-
-
-export default {
-  blockLength,
-  ivLength,
-  encrypt,
-  decrypt,
-  getNonce
 };
+
+EAX.blockLength = blockLength;
+EAX.ivLength = ivLength;
+
+export default EAX;
 
 
 //////////////////////////
@@ -134,28 +168,4 @@ function xor3(a, b, c) {
 
 function concat(...arrays) {
   return util.concatUint8Array(arrays);
-}
-
-function CTR(plaintext, key, iv) {
-  if (util.getWebCryptoAll() && key.length !== 24) { // WebCrypto (no 192 bit support) see: https://www.chromium.org/blink/webcrypto#TOC-AES-support
-    return webCtr(plaintext, key, iv);
-  } else if (util.getNodeCrypto()) { // Node crypto library
-    return nodeCtr(plaintext, key, iv);
-  } // asm.js fallback
-  return Promise.resolve(AES_CTR.encrypt(plaintext, key, iv));
-}
-
-function webCtr(pt, key, iv) {
-  return webCrypto.importKey('raw', key, { name: 'AES-CTR', length: key.length * 8 }, false, ['encrypt'])
-    .then(keyObj => webCrypto.encrypt({ name: 'AES-CTR', counter: iv, length: blockLength * 8 }, keyObj, pt))
-    .then(ct => new Uint8Array(ct));
-}
-
-function nodeCtr(pt, key, iv) {
-  pt = new Buffer(pt);
-  key = new Buffer(key);
-  iv = new Buffer(iv);
-  const en = new nodeCrypto.createCipheriv('aes-' + (key.length * 8) + '-ctr', key, iv);
-  const ct = Buffer.concat([en.update(pt), en.final()]);
-  return Promise.resolve(new Uint8Array(ct));
 }

--- a/src/crypto/eax.js
+++ b/src/crypto/eax.js
@@ -163,5 +163,6 @@ EAX.getNonce = function(iv, chunkIndex) {
 
 EAX.blockLength = blockLength;
 EAX.ivLength = ivLength;
+EAX.tagLength = tagLength;
 
 export default EAX;

--- a/src/crypto/eax.js
+++ b/src/crypto/eax.js
@@ -1,0 +1,156 @@
+// OpenPGP.js - An OpenPGP implementation in javascript
+// Copyright (C) 2018 ProtonTech AG
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 3.0 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+/**
+ * @fileoverview This module implements AES-EAX en/decryption on top of
+ * native AES-CTR using either the WebCrypto API or Node.js' crypto API.
+ * @requires asmcrypto.js
+ * @requires util
+ * @module crypto/eax
+ */
+
+import { AES_CMAC } from 'asmcrypto.js/src/aes/cmac/exports';
+import { AES_CTR } from 'asmcrypto.js/src/aes/ctr/exports';
+import util from '../util';
+
+const webCrypto = util.getWebCryptoAll();
+const nodeCrypto = util.getNodeCrypto();
+const Buffer = util.getNodeBuffer();
+
+
+const blockLength = 16;
+const ivLength = blockLength;
+const tagLength = blockLength;
+
+const zero = new Uint8Array([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
+const one = new Uint8Array([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]);
+const two = new Uint8Array([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2]);
+
+
+/**
+ * Encrypt plaintext input.
+ * @param  {String}     cipher      The symmetric cipher algorithm to use e.g. 'aes128'
+ * @param  {Uint8Array} plaintext   The cleartext input to be encrypted
+ * @param  {Uint8Array} key         The encryption key
+ * @param  {Uint8Array} nonce       The nonce (16 bytes)
+ * @param  {Uint8Array} adata       Associated data to sign
+ * @returns {Promise<Uint8Array>}    The ciphertext output
+ */
+async function encrypt(cipher, plaintext, key, nonce, adata) {
+  if (cipher.substr(0, 3) !== 'aes') {
+    throw new Error('EAX mode supports only AES cipher');
+  }
+
+  const _nonce = OMAC(zero, nonce, key);
+  const _adata = OMAC(one, adata, key);
+  const ciphered = await CTR(plaintext, key, _nonce);
+  const _ciphered = OMAC(two, ciphered, key);
+  const tag = xor3(_nonce, _ciphered, _adata); // Assumes that OMAC(*).length === tagLength.
+  return concat(ciphered, tag);
+}
+
+/**
+ * Decrypt ciphertext input.
+ * @param  {String}     cipher       The symmetric cipher algorithm to use e.g. 'aes128'
+ * @param  {Uint8Array} ciphertext   The ciphertext input to be decrypted
+ * @param  {Uint8Array} key          The encryption key
+ * @param  {Uint8Array} nonce        The nonce (16 bytes)
+ * @param  {Uint8Array} adata        Associated data to verify
+ * @returns {Promise<Uint8Array>}     The plaintext output
+ */
+async function decrypt(cipher, ciphertext, key, nonce, adata) {
+  if (cipher.substr(0, 3) !== 'aes') {
+    throw new Error('EAX mode supports only AES cipher');
+  }
+
+  if (ciphertext.length < tagLength) throw new Error('Invalid EAX ciphertext');
+  const ciphered = ciphertext.subarray(0, ciphertext.length - tagLength);
+  const tag = ciphertext.subarray(ciphertext.length - tagLength);
+  const _nonce = OMAC(zero, nonce, key);
+  const _adata = OMAC(one, adata, key);
+  const _ciphered = OMAC(two, ciphered, key);
+  const _tag = xor3(_nonce, _ciphered, _adata); // Assumes that OMAC(*).length === tagLength.
+  if (!util.equalsUint8Array(tag, _tag)) throw new Error('Authentication tag mismatch in EAX ciphertext');
+  const plaintext = await CTR(ciphered, key, _nonce);
+  return plaintext;
+}
+
+/**
+ * Get EAX nonce as defined by {@link https://tools.ietf.org/html/draft-ietf-openpgp-rfc4880bis-04#section-5.16.1|RFC4880bis-04, section 5.16.1}.
+ * @param  {Uint8Array} iv           The initialization vector (16 bytes)
+ * @param  {Uint8Array} chunkIndex   The chunk index (8 bytes)
+ */
+function getNonce(iv, chunkIndex) {
+  const nonce = iv.slice();
+  for (let i = 0; i < chunkIndex.length; i++) {
+    nonce[8 + i] ^= chunkIndex[i];
+  }
+  return nonce;
+}
+
+
+export default {
+  blockLength,
+  ivLength,
+  encrypt,
+  decrypt,
+  getNonce
+};
+
+
+//////////////////////////
+//                      //
+//   Helper functions   //
+//                      //
+//////////////////////////
+
+
+function xor3(a, b, c) {
+  return a.map((n, i) => n ^ b[i] ^ c[i]);
+}
+
+function concat(...arrays) {
+  return util.concatUint8Array(arrays);
+}
+
+function OMAC(t, message, key) {
+  return AES_CMAC.bytes(concat(t, message), key);
+}
+
+function CTR(plaintext, key, iv) {
+  if (webCrypto && key.length !== 24) { // WebCrypto (no 192 bit support) see: https://www.chromium.org/blink/webcrypto#TOC-AES-support
+    return webCtr(plaintext, key, iv);
+  } else if (nodeCrypto) { // Node crypto library
+    return nodeCtr(plaintext, key, iv);
+  } // asm.js fallback
+  return Promise.resolve(AES_CTR.encrypt(plaintext, key, iv));
+}
+
+function webCtr(pt, key, iv) {
+  return webCrypto.importKey('raw', key, { name: 'AES-CTR', length: key.length * 8 }, false, ['encrypt'])
+    .then(keyObj => webCrypto.encrypt({ name: 'AES-CTR', counter: iv, length: blockLength * 8 }, keyObj, pt))
+    .then(ct => new Uint8Array(ct));
+}
+
+function nodeCtr(pt, key, iv) {
+  pt = new Buffer(pt);
+  key = new Buffer(key);
+  iv = new Buffer(iv);
+  const en = new nodeCrypto.createCipheriv('aes-' + (key.length * 8) + '-ctr', key, iv);
+  const ct = Buffer.concat([en.update(pt), en.final()]);
+  return Promise.resolve(new Uint8Array(ct));
+}

--- a/src/crypto/gcm.js
+++ b/src/crypto/gcm.js
@@ -49,9 +49,9 @@ function encrypt(cipher, plaintext, key, iv) {
     return Promise.reject(new Error('GCM mode supports only AES cipher'));
   }
 
-  if (webCrypto && key.length !== 24) { // WebCrypto (no 192 bit support) see: https://www.chromium.org/blink/webcrypto#TOC-AES-support
+  if (util.getWebCrypto() && key.length !== 24) { // WebCrypto (no 192 bit support) see: https://www.chromium.org/blink/webcrypto#TOC-AES-support
     return webEncrypt(plaintext, key, iv);
-  } else if (nodeCrypto) { // Node crypto library
+  } else if (util.getNodeCrypto()) { // Node crypto library
     return nodeEncrypt(plaintext, key, iv);
   } // asm.js fallback
   return Promise.resolve(AES_GCM.encrypt(plaintext, key, iv));
@@ -70,9 +70,9 @@ function decrypt(cipher, ciphertext, key, iv) {
     return Promise.reject(new Error('GCM mode supports only AES cipher'));
   }
 
-  if (webCrypto && key.length !== 24) { // WebCrypto (no 192 bit support) see: https://www.chromium.org/blink/webcrypto#TOC-AES-support
+  if (util.getWebCrypto() && key.length !== 24) { // WebCrypto (no 192 bit support) see: https://www.chromium.org/blink/webcrypto#TOC-AES-support
     return webDecrypt(ciphertext, key, iv);
-  } else if (nodeCrypto) { // Node crypto library
+  } else if (util.getNodeCrypto()) { // Node crypto library
     return nodeDecrypt(ciphertext, key, iv);
   } // asm.js fallback
   return Promise.resolve(AES_GCM.decrypt(ciphertext, key, iv));

--- a/src/crypto/gcm.js
+++ b/src/crypto/gcm.js
@@ -118,5 +118,6 @@ GCM.getNonce = function(iv, chunkIndex) {
 
 GCM.blockLength = blockLength;
 GCM.ivLength = ivLength;
+GCM.tagLength = tagLength;
 
 export default GCM;

--- a/src/crypto/gcm.js
+++ b/src/crypto/gcm.js
@@ -32,95 +32,91 @@ const webCrypto = util.getWebCrypto(); // no GCM support in IE11, Safari 9
 const nodeCrypto = util.getNodeCrypto();
 const Buffer = util.getNodeBuffer();
 
+const blockLength = 16;
 const ivLength = 12; // size of the IV in bytes
-const TAG_LEN = 16; // size of the tag in bytes
+const tagLength = 16; // size of the tag in bytes
 const ALGO = 'AES-GCM';
 
 /**
- * Encrypt plaintext input.
+ * Class to en/decrypt using GCM mode.
  * @param  {String}     cipher      The symmetric cipher algorithm to use e.g. 'aes128'
- * @param  {Uint8Array} plaintext   The cleartext input to be encrypted
  * @param  {Uint8Array} key         The encryption key
- * @param  {Uint8Array} iv          The initialization vector (12 bytes)
- * @returns {Promise<Uint8Array>}    The ciphertext output
  */
-function encrypt(cipher, plaintext, key, iv, adata) {
+async function GCM(cipher, key) {
   if (cipher.substr(0, 3) !== 'aes') {
-    return Promise.reject(new Error('GCM mode supports only AES cipher'));
+    throw new Error('GCM mode supports only AES cipher');
   }
 
   if (util.getWebCrypto() && key.length !== 24) { // WebCrypto (no 192 bit support) see: https://www.chromium.org/blink/webcrypto#TOC-AES-support
-    return webEncrypt(plaintext, key, iv, adata);
-  } else if (util.getNodeCrypto()) { // Node crypto library
-    return nodeEncrypt(plaintext, key, iv, adata);
-  } // asm.js fallback
-  return Promise.resolve(AES_GCM.encrypt(plaintext, key, iv, adata));
+    key = await webCrypto.importKey('raw', key, { name: ALGO }, false, ['encrypt', 'decrypt']);
+
+    return {
+      encrypt: async function(pt, iv, adata) {
+        const ct = await webCrypto.encrypt({ name: ALGO, iv, adata }, key, pt);
+        return new Uint8Array(ct);
+      },
+
+      decrypt: async function(ct, iv, adata) {
+        const pt = await webCrypto.decrypt({ name: ALGO, iv, adata }, key, ct);
+        return new Uint8Array(pt);
+      }
+    };
+  }
+
+  if (util.getNodeCrypto()) { // Node crypto library
+    key = new Buffer(key);
+
+    return {
+      encrypt: async function(pt, iv, adata) {
+        pt = new Buffer(pt);
+        iv = new Buffer(iv);
+        const en = new nodeCrypto.createCipheriv('aes-' + (key.length * 8) + '-gcm', key, iv);
+        en.setAAD(adata);
+        const ct = Buffer.concat([en.update(pt), en.final(), en.getAuthTag()]); // append auth tag to ciphertext
+        return new Uint8Array(ct);
+      },
+
+      decrypt: async function(ct, iv, adata) {
+        ct = new Buffer(ct);
+        iv = new Buffer(iv);
+        const de = new nodeCrypto.createDecipheriv('aes-' + (key.length * 8) + '-gcm', key, iv);
+        de.setAAD(adata);
+        de.setAuthTag(ct.slice(ct.length - tagLength, ct.length)); // read auth tag at end of ciphertext
+        const pt = Buffer.concat([de.update(ct.slice(0, ct.length - tagLength)), de.final()]);
+        return new Uint8Array(pt);
+      }
+    };
+  }
+
+  return {
+    encrypt: async function(pt, iv, adata) {
+      return AES_GCM.encrypt(pt, key, iv, adata);
+    },
+
+    decrypt: async function(ct, iv, adata) {
+      return AES_GCM.decrypt(ct, key, iv, adata);
+    }
+  };
 }
+
 
 /**
- * Decrypt ciphertext input.
- * @param  {String}     cipher       The symmetric cipher algorithm to use e.g. 'aes128'
- * @param  {Uint8Array} ciphertext   The ciphertext input to be decrypted
- * @param  {Uint8Array} key          The encryption key
+ * Get GCM nonce. Note: this operation is not defined by the standard.
+ * A future version of the standard may define GCM mode differently,
+ * hopefully under a different ID (we use Private/Experimental algorithm
+ * ID 100) so that we can maintain backwards compatibility.
  * @param  {Uint8Array} iv           The initialization vector (12 bytes)
- * @returns {Promise<Uint8Array>}     The plaintext output
+ * @param  {Uint8Array} chunkIndex   The chunk index (8 bytes)
  */
-function decrypt(cipher, ciphertext, key, iv, adata) {
-  if (cipher.substr(0, 3) !== 'aes') {
-    return Promise.reject(new Error('GCM mode supports only AES cipher'));
+GCM.getNonce = function(iv, chunkIndex) {
+  const nonce = iv.slice();
+  for (let i = 0; i < chunkIndex.length; i++) {
+    nonce[4 + i] ^= chunkIndex[i];
   }
-
-  if (util.getWebCrypto() && key.length !== 24) { // WebCrypto (no 192 bit support) see: https://www.chromium.org/blink/webcrypto#TOC-AES-support
-    return webDecrypt(ciphertext, key, iv, adata);
-  } else if (util.getNodeCrypto()) { // Node crypto library
-    return nodeDecrypt(ciphertext, key, iv, adata);
-  } // asm.js fallback
-  return Promise.resolve(AES_GCM.decrypt(ciphertext, key, iv, adata));
-}
-
-export default {
-  ivLength,
-  encrypt,
-  decrypt
+  return nonce;
 };
 
+GCM.blockLength = blockLength;
+GCM.ivLength = ivLength;
 
-//////////////////////////
-//                      //
-//   Helper functions   //
-//                      //
-//////////////////////////
-
-
-function webEncrypt(pt, key, iv, adata) {
-  return webCrypto.importKey('raw', key, { name: ALGO }, false, ['encrypt'])
-    .then(keyObj => webCrypto.encrypt({ name: ALGO, iv, adata }, keyObj, pt))
-    .then(ct => new Uint8Array(ct));
-}
-
-function webDecrypt(ct, key, iv, adata) {
-  return webCrypto.importKey('raw', key, { name: ALGO }, false, ['decrypt'])
-    .then(keyObj => webCrypto.decrypt({ name: ALGO, iv, adata }, keyObj, ct))
-    .then(pt => new Uint8Array(pt));
-}
-
-function nodeEncrypt(pt, key, iv, adata) {
-  pt = new Buffer(pt);
-  key = new Buffer(key);
-  iv = new Buffer(iv);
-  const en = new nodeCrypto.createCipheriv('aes-' + (key.length * 8) + '-gcm', key, iv);
-  en.setAAD(adata);
-  const ct = Buffer.concat([en.update(pt), en.final(), en.getAuthTag()]); // append auth tag to ciphertext
-  return Promise.resolve(new Uint8Array(ct));
-}
-
-function nodeDecrypt(ct, key, iv, adata) {
-  ct = new Buffer(ct);
-  key = new Buffer(key);
-  iv = new Buffer(iv);
-  const de = new nodeCrypto.createDecipheriv('aes-' + (key.length * 8) + '-gcm', key, iv);
-  de.setAAD(adata);
-  de.setAuthTag(ct.slice(ct.length - TAG_LEN, ct.length)); // read auth tag at end of ciphertext
-  const pt = Buffer.concat([de.update(ct.slice(0, ct.length - TAG_LEN)), de.final()]);
-  return Promise.resolve(new Uint8Array(pt));
-}
+export default GCM;

--- a/src/crypto/index.js
+++ b/src/crypto/index.js
@@ -14,6 +14,7 @@ import hash from './hash';
 import cfb from './cfb';
 import gcm from './gcm';
 import eax from './eax';
+import ocb from './ocb';
 import publicKey from './public_key';
 import signature from './signature';
 import random from './random';
@@ -34,6 +35,8 @@ const mod = {
   gcm: gcm,
   /** @see module:crypto/eax */
   eax: eax,
+  /** @see module:crypto/ocb */
+  ocb: ocb,
   /** @see module:crypto/public_key */
   publicKey: publicKey,
   /** @see module:crypto/signature */

--- a/src/crypto/index.js
+++ b/src/crypto/index.js
@@ -13,6 +13,7 @@ import cipher from './cipher';
 import hash from './hash';
 import cfb from './cfb';
 import gcm from './gcm';
+import eax from './eax';
 import publicKey from './public_key';
 import signature from './signature';
 import random from './random';
@@ -31,6 +32,8 @@ const mod = {
   cfb: cfb,
   /** @see module:crypto/gcm */
   gcm: gcm,
+  /** @see module:crypto/eax */
+  eax: eax,
   /** @see module:crypto/public_key */
   publicKey: publicKey,
   /** @see module:crypto/signature */

--- a/src/crypto/ocb.js
+++ b/src/crypto/ocb.js
@@ -1,0 +1,312 @@
+// OpenPGP.js - An OpenPGP implementation in javascript
+// Copyright (C) 2018 ProtonTech AG
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 3.0 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+/**
+ * @fileoverview This module implements AES-OCB en/decryption.
+ * @requires crypto/cipher
+ * @requires util
+ * @module crypto/ocb
+ */
+
+import ciphers from './cipher';
+import util from '../util';
+
+
+const blockLength = 16;
+const ivLength = 15;
+
+// https://tools.ietf.org/html/draft-ietf-openpgp-rfc4880bis-04#section-5.16.2:
+// While OCB [RFC7253] allows the authentication tag length to be of any
+// number up to 128 bits long, this document requires a fixed
+// authentication tag length of 128 bits (16 octets) for simplicity.
+const tagLength = 16;
+
+
+const { shiftLeft, shiftRight } = util;
+
+
+function zeros(bytes) {
+  return new Uint8Array(bytes);
+}
+
+function ntz(n) {
+  let ntz = 0;
+  for(let i = 1; (n & i) === 0; i <<= 1) {
+    ntz++;
+  }
+  return ntz;
+}
+
+function set_xor(S, T) {
+  for (let i = 0; i < S.length; i++) {
+    S[i] ^= T[i];
+  }
+  return S;
+}
+
+function xor(S, T) {
+  return set_xor(S.slice(), T);
+}
+
+function concat(...arrays) {
+  return util.concatUint8Array(arrays);
+}
+
+function double(S) {
+  const double = S.slice();
+  shiftLeft(double, 1);
+  if (S[0] & 0b10000000) {
+    double[15] ^= 0b10000111;
+  }
+  return double;
+}
+
+
+function constructKeyVariables(cipher, key, text, adata) {
+  const aes = new ciphers[cipher](key);
+  const encipher = aes.encrypt.bind(aes);
+  const decipher = aes.decrypt.bind(aes);
+
+  const L_x = encipher(zeros(16));
+  const L_$ = double(L_x);
+  const L = [];
+  L[0] = double(L_$);
+
+  const max_ntz = util.nbits(Math.max(text.length, adata.length) >> 4) - 1;
+  for (let i = 1; i <= max_ntz; i++) {
+    L[i] = double(L[i - 1]);
+  }
+
+  L.x = L_x;
+  L.$ = L_$;
+
+  return { encipher, decipher, L };
+}
+
+function hash(kv, key, adata) {
+  if (!adata.length) {
+    // Fast path
+    return zeros(16);
+  }
+
+  const { encipher, L } = kv;
+
+  //
+  // Consider A as a sequence of 128-bit blocks
+  //
+  const m = adata.length >> 4;
+
+  const offset = zeros(16);
+  const sum = zeros(16);
+  for (let i = 0; i < m; i++) {
+    set_xor(offset, L[ntz(i + 1)]);
+    set_xor(sum, encipher(xor(offset, adata)));
+    adata = adata.subarray(16);
+  }
+
+  //
+  // Process any final partial block; compute final hash value
+  //
+  if (adata.length) {
+    set_xor(offset, L.x);
+
+    const cipherInput = zeros(16);
+    cipherInput.set(adata, 0);
+    cipherInput[adata.length] = 0b10000000;
+    set_xor(cipherInput, offset);
+
+    set_xor(sum, encipher(cipherInput));
+  }
+
+  return sum;
+}
+
+
+/**
+ * Encrypt plaintext input.
+ * @param  {String}     cipher      The symmetric cipher algorithm to use e.g. 'aes128'
+ * @param  {Uint8Array} plaintext   The cleartext input to be encrypted
+ * @param  {Uint8Array} key         The encryption key
+ * @param  {Uint8Array} nonce       The nonce (15 bytes)
+ * @param  {Uint8Array} adata       Associated data to sign
+ * @returns {Promise<Uint8Array>}    The ciphertext output
+ */
+async function encrypt(cipher, plaintext, key, nonce, adata) {
+  //
+  // Consider P as a sequence of 128-bit blocks
+  //
+  const m = plaintext.length >> 4;
+
+  //
+  // Key-dependent variables
+  //
+  const kv = constructKeyVariables(cipher, key, plaintext, adata);
+  const { encipher, L } = kv;
+
+  //
+  // Nonce-dependent and per-encryption variables
+  //
+  // We assume here that TAGLEN mod 128 == 0 (tagLength === 16).
+  const Nonce = concat(zeros(15 - nonce.length), new Uint8Array([1]), nonce);
+  const bottom = Nonce[15] & 0b111111;
+  Nonce[15] &= 0b11000000;
+  const Ktop = encipher(Nonce);
+  const Stretch = concat(Ktop, xor(Ktop.subarray(0, 8), Ktop.subarray(1, 9)));
+  //    Offset_0 = Stretch[1+bottom..128+bottom]
+  const offset = shiftRight(Stretch.subarray(0 + (bottom >> 3), 17 + (bottom >> 3)), 8 - (bottom & 7)).subarray(1);
+  const checksum = zeros(16);
+
+  const C = new Uint8Array(plaintext.length + tagLength);
+
+  //
+  // Process any whole blocks
+  //
+  let i;
+  let pos = 0;
+  for (i = 0; i < m; i++) {
+    set_xor(offset, L[ntz(i + 1)]);
+    C.set(xor(offset, encipher(xor(offset, plaintext))), pos);
+    set_xor(checksum, plaintext);
+
+    plaintext = plaintext.subarray(16);
+    pos += 16;
+  }
+
+  //
+  // Process any final partial block and compute raw tag
+  //
+  if (plaintext.length) {
+    set_xor(offset, L.x);
+    const Pad = encipher(offset);
+    C.set(xor(plaintext, Pad), pos);
+
+    // Checksum_* = Checksum_m xor (P_* || 1 || zeros(127-bitlen(P_*)))
+    const xorInput = zeros(16);
+    xorInput.set(plaintext, 0);
+    xorInput[plaintext.length] = 0b10000000;
+    set_xor(checksum, xorInput);
+    pos += plaintext.length;
+  }
+  const Tag = xor(encipher(xor(xor(checksum, offset), L.$)), hash(kv, key, adata));
+
+  //
+  // Assemble ciphertext
+  //
+  C.set(Tag, pos);
+  return C;
+}
+
+
+/**
+ * Decrypt ciphertext input.
+ * @param  {String}     cipher       The symmetric cipher algorithm to use e.g. 'aes128'
+ * @param  {Uint8Array} ciphertext   The ciphertext input to be decrypted
+ * @param  {Uint8Array} key          The encryption key
+ * @param  {Uint8Array} nonce        The nonce (15 bytes)
+ * @param  {Uint8Array} adata        Associated data to verify
+ * @returns {Promise<Uint8Array>}     The plaintext output
+ */
+async function decrypt(cipher, ciphertext, key, nonce, adata) {
+  //
+  // Consider C as a sequence of 128-bit blocks
+  //
+  const T = ciphertext.subarray(ciphertext.length - tagLength);
+  ciphertext = ciphertext.subarray(0, ciphertext.length - tagLength);
+  const m = ciphertext.length >> 4;
+
+  //
+  // Key-dependent variables
+  //
+  const kv = constructKeyVariables(cipher, key, ciphertext, adata);
+  const { encipher, decipher, L } = kv;
+
+  //
+  // Nonce-dependent and per-encryption variables
+  //
+  // We assume here that TAGLEN mod 128 == 0 (tagLength === 16).
+  const Nonce = concat(zeros(15 - nonce.length), new Uint8Array([1]), nonce);
+  const bottom = Nonce[15] & 0b111111;
+  Nonce[15] &= 0b11000000;
+  const Ktop = encipher(Nonce);
+  const Stretch = concat(Ktop, xor(Ktop.subarray(0, 8), Ktop.subarray(1, 9)));
+  //    Offset_0 = Stretch[1+bottom..128+bottom]
+  const offset = shiftRight(Stretch.subarray(0 + (bottom >> 3), 17 + (bottom >> 3)), 8 - (bottom & 7)).subarray(1);
+  const checksum = zeros(16);
+
+  const P = new Uint8Array(ciphertext.length);
+
+  //
+  // Process any whole blocks
+  //
+  let i;
+  let pos = 0;
+  for (i = 0; i < m; i++) {
+    set_xor(offset, L[ntz(i + 1)]);
+    P.set(xor(offset, decipher(xor(offset, ciphertext))), pos);
+    set_xor(checksum, P.subarray(pos));
+
+    ciphertext = ciphertext.subarray(16);
+    pos += 16;
+  }
+
+  //
+  // Process any final partial block and compute raw tag
+  //
+  if (ciphertext.length) {
+    set_xor(offset, L.x);
+    const Pad = encipher(offset);
+    P.set(xor(ciphertext, Pad), pos);
+
+    // Checksum_* = Checksum_m xor (P_* || 1 || zeros(127-bitlen(P_*)))
+    const xorInput = zeros(16);
+    xorInput.set(P.subarray(pos), 0);
+    xorInput[ciphertext.length] = 0b10000000;
+    set_xor(checksum, xorInput);
+    pos += ciphertext.length;
+  }
+  const Tag = xor(encipher(xor(xor(checksum, offset), L.$)), hash(kv, key, adata));
+
+  //
+  // Check for validity and assemble plaintext
+  //
+  if (!util.equalsUint8Array(Tag, T)) {
+    throw new Error('Authentication tag mismatch in OCB ciphertext');
+  }
+  return P;
+}
+
+/**
+ * Get OCB nonce as defined by {@link https://tools.ietf.org/html/draft-ietf-openpgp-rfc4880bis-04#section-5.16.2|RFC4880bis-04, section 5.16.2}.
+ * @param  {Uint8Array} iv           The initialization vector (15 bytes)
+ * @param  {Uint8Array} chunkIndex   The chunk index (8 bytes)
+ */
+function getNonce(iv, chunkIndex) {
+  const nonce = iv.slice();
+  for (let i = 0; i < chunkIndex.length; i++) {
+    nonce[7 + i] ^= chunkIndex[i];
+  }
+  return nonce;
+}
+
+
+export default {
+  blockLength,
+  ivLength,
+  encrypt,
+  decrypt,
+  getNonce
+};

--- a/src/crypto/ocb.js
+++ b/src/crypto/ocb.js
@@ -55,16 +55,6 @@ function xor(S, T) {
   return xorMut(S.slice(), T);
 }
 
-function double(S) {
-  const double = S.slice();
-  util.shiftLeft(double, 1);
-  if (S[0] & 0b10000000) {
-    double[15] ^= 0b10000111;
-  }
-  return double;
-}
-
-
 const zeroBlock = new Uint8Array(blockLength);
 const one = new Uint8Array([1]);
 
@@ -86,9 +76,9 @@ async function OCB(cipher, key) {
     const decipher = aes.decrypt.bind(aes);
 
     const mask_x = encipher(zeroBlock);
-    const mask_$ = double(mask_x);
+    const mask_$ = util.double(mask_x);
     const mask = [];
-    mask[0] = double(mask_$);
+    mask[0] = util.double(mask_$);
 
 
     mask.x = mask_x;
@@ -101,7 +91,7 @@ async function OCB(cipher, key) {
     const { mask } = kv;
     const newMaxNtz = util.nbits(Math.max(text.length, adata.length) >> 4) - 1;
     for (let i = maxNtz + 1; i <= newMaxNtz; i++) {
-      mask[i] = double(mask[i - 1]);
+      mask[i] = util.double(mask[i - 1]);
     }
     maxNtz = newMaxNtz;
   }

--- a/src/crypto/ocb.js
+++ b/src/crypto/ocb.js
@@ -66,30 +66,29 @@ const one = new Uint8Array([1]);
 async function OCB(cipher, key) {
 
   let maxNtz = 0;
-  let kv;
+  let encipher;
+  let decipher;
+  let mask;
 
   constructKeyVariables(cipher, key);
 
   function constructKeyVariables(cipher, key) {
     const aes = new ciphers[cipher](key);
-    const encipher = aes.encrypt.bind(aes);
-    const decipher = aes.decrypt.bind(aes);
+    encipher = aes.encrypt.bind(aes);
+    decipher = aes.decrypt.bind(aes);
 
     const mask_x = encipher(zeroBlock);
     const mask_$ = util.double(mask_x);
-    const mask = [];
+    mask = [];
     mask[0] = util.double(mask_$);
 
 
     mask.x = mask_x;
     mask.$ = mask_$;
-
-    kv = { encipher, decipher, mask };
   }
 
   function extendKeyVariables(text, adata) {
-    const { mask } = kv;
-    const newMaxNtz = util.nbits(Math.max(text.length, adata.length) >> 4) - 1;
+    const newMaxNtz = util.nbits(Math.max(text.length, adata.length) / blockLength | 0) - 1;
     for (let i = maxNtz + 1; i <= newMaxNtz; i++) {
       mask[i] = util.double(mask[i - 1]);
     }
@@ -102,19 +101,17 @@ async function OCB(cipher, key) {
       return zeroBlock;
     }
 
-    const { encipher, mask } = kv;
-
     //
     // Consider A as a sequence of 128-bit blocks
     //
-    const m = adata.length >> 4;
+    const m = adata.length / blockLength | 0;
 
-    const offset = new Uint8Array(16);
-    const sum = new Uint8Array(16);
+    const offset = new Uint8Array(blockLength);
+    const sum = new Uint8Array(blockLength);
     for (let i = 0; i < m; i++) {
       xorMut(offset, mask[ntz(i + 1)]);
       xorMut(sum, encipher(xor(offset, adata)));
-      adata = adata.subarray(16);
+      adata = adata.subarray(blockLength);
     }
 
     //
@@ -123,7 +120,7 @@ async function OCB(cipher, key) {
     if (adata.length) {
       xorMut(offset, mask.x);
 
-      const cipherInput = new Uint8Array(16);
+      const cipherInput = new Uint8Array(blockLength);
       cipherInput.set(adata, 0);
       cipherInput[adata.length] = 0b10000000;
       xorMut(cipherInput, offset);
@@ -132,6 +129,92 @@ async function OCB(cipher, key) {
     }
 
     return sum;
+  }
+
+  /**
+   * Encrypt/decrypt data.
+   * @param  {encipher|decipher} fn   Encryption/decryption block cipher function
+   * @param  {Uint8Array} text        The cleartext or ciphertext (without tag) input
+   * @param  {Uint8Array} nonce       The nonce (15 bytes)
+   * @param  {Uint8Array} adata       Associated data to sign
+   * @returns {Promise<Uint8Array>}    The ciphertext or plaintext output, with tag appended in both cases
+   */
+  function crypt(fn, text, nonce, adata) {
+    //
+    // Consider P as a sequence of 128-bit blocks
+    //
+    const m = text.length / blockLength | 0;
+
+    //
+    // Key-dependent variables
+    //
+    extendKeyVariables(text, adata);
+
+    //
+    // Nonce-dependent and per-encryption variables
+    //
+    //    Nonce = num2str(TAGLEN mod 128,7) || zeros(120-bitlen(N)) || 1 || N
+    // Note: We assume here that tagLength mod 16 == 0.
+    const paddedNonce = util.concatUint8Array([zeroBlock.subarray(0, ivLength - nonce.length), one, nonce]);
+    //    bottom = str2num(Nonce[123..128])
+    const bottom = paddedNonce[blockLength - 1] & 0b111111;
+    //    Ktop = ENCIPHER(K, Nonce[1..122] || zeros(6))
+    paddedNonce[blockLength - 1] &= 0b11000000;
+    const kTop = encipher(paddedNonce);
+    //    Stretch = Ktop || (Ktop[1..64] xor Ktop[9..72])
+    const stretched = util.concatUint8Array([kTop, xor(kTop.subarray(0, 8), kTop.subarray(1, 9))]);
+    //    Offset_0 = Stretch[1+bottom..128+bottom]
+    const offset = util.shiftRight(stretched.subarray(0 + (bottom >> 3), 17 + (bottom >> 3)), 8 - (bottom & 7)).subarray(1);
+    //    Checksum_0 = zeros(128)
+    const checksum = new Uint8Array(blockLength);
+
+    const ct = new Uint8Array(text.length + tagLength);
+
+    //
+    // Process any whole blocks
+    //
+    let i;
+    let pos = 0;
+    for (i = 0; i < m; i++) {
+      // Offset_i = Offset_{i-1} xor L_{ntz(i)}
+      xorMut(offset, mask[ntz(i + 1)]);
+      // C_i = Offset_i xor ENCIPHER(K, P_i xor Offset_i)
+      // P_i = Offset_i xor DECIPHER(K, C_i xor Offset_i)
+      ct.set(xorMut(fn(xor(offset, text)), offset), pos);
+      // Checksum_i = Checksum_{i-1} xor P_i
+      xorMut(checksum, fn === encipher ? text : ct.subarray(pos));
+
+      text = text.subarray(blockLength);
+      pos += blockLength;
+    }
+
+    //
+    // Process any final partial block and compute raw tag
+    //
+    if (text.length) {
+      // Offset_* = Offset_m xor L_*
+      xorMut(offset, mask.x);
+      // Pad = ENCIPHER(K, Offset_*)
+      const padding = encipher(offset);
+      // C_* = P_* xor Pad[1..bitlen(P_*)]
+      ct.set(xor(text, padding), pos);
+
+      // Checksum_* = Checksum_m xor (P_* || 1 || new Uint8Array(127-bitlen(P_*)))
+      const xorInput = new Uint8Array(blockLength);
+      xorInput.set(fn === encipher ? text : ct.subarray(pos, -tagLength), 0);
+      xorInput[text.length] = 0b10000000;
+      xorMut(checksum, xorInput);
+      pos += text.length;
+    }
+    // Tag = ENCIPHER(K, Checksum_* xor Offset_* xor L_$) xor HASH(K,A)
+    const tag = xorMut(encipher(xorMut(xorMut(checksum, offset), mask.$)), hash(adata));
+
+    //
+    // Assemble ciphertext
+    //
+    // C = C_1 || C_2 || ... || C_m || C_* || Tag[1..TAGLEN]
+    ct.set(tag, pos);
+    return ct;
   }
 
 
@@ -144,145 +227,28 @@ async function OCB(cipher, key) {
      * @returns {Promise<Uint8Array>}    The ciphertext output
      */
     encrypt: async function(plaintext, nonce, adata) {
-      //
-      // Consider P as a sequence of 128-bit blocks
-      //
-      const m = plaintext.length >> 4;
-
-      //
-      // Key-dependent variables
-      //
-      extendKeyVariables(plaintext, adata);
-      const { encipher, mask } = kv;
-
-      //
-      // Nonce-dependent and per-encryption variables
-      //
-      // We assume here that tagLength mod 16 == 0.
-      const paddedNonce = util.concatUint8Array([zeroBlock.subarray(0, 15 - nonce.length), one, nonce]);
-      const bottom = paddedNonce[15] & 0b111111;
-      paddedNonce[15] &= 0b11000000;
-      const kTop = encipher(paddedNonce);
-      const stretched = util.concatUint8Array([kTop, xor(kTop.subarray(0, 8), kTop.subarray(1, 9))]);
-      //    Offset_0 = Stretch[1+bottom..128+bottom]
-      const offset = util.shiftRight(stretched.subarray(0 + (bottom >> 3), 17 + (bottom >> 3)), 8 - (bottom & 7)).subarray(1);
-      const checksum = new Uint8Array(16);
-
-      const ct = new Uint8Array(plaintext.length + tagLength);
-
-      //
-      // Process any whole blocks
-      //
-      let i;
-      let pos = 0;
-      for (i = 0; i < m; i++) {
-        xorMut(offset, mask[ntz(i + 1)]);
-        ct.set(xorMut(encipher(xor(offset, plaintext)), offset), pos);
-        xorMut(checksum, plaintext);
-
-        plaintext = plaintext.subarray(16);
-        pos += 16;
-      }
-
-      //
-      // Process any final partial block and compute raw tag
-      //
-      if (plaintext.length) {
-        xorMut(offset, mask.x);
-        const padding = encipher(offset);
-        ct.set(xor(plaintext, padding), pos);
-
-        // Checksum_* = Checksum_m xor (P_* || 1 || new Uint8Array(127-bitlen(P_*)))
-        const xorInput = new Uint8Array(16);
-        xorInput.set(plaintext, 0);
-        xorInput[plaintext.length] = 0b10000000;
-        xorMut(checksum, xorInput);
-        pos += plaintext.length;
-      }
-      const tag = xorMut(encipher(xorMut(xorMut(checksum, offset), mask.$)), hash(adata));
-
-      //
-      // Assemble ciphertext
-      //
-      ct.set(tag, pos);
-      return ct;
+      return crypt(encipher, plaintext, nonce, adata);
     },
-
 
     /**
      * Decrypt ciphertext input.
-     * @param  {Uint8Array} ciphertext   The ciphertext input to be decrypted
-     * @param  {Uint8Array} nonce        The nonce (15 bytes)
-     * @param  {Uint8Array} adata        Associated data to verify
-     * @returns {Promise<Uint8Array>}     The plaintext output
+     * @param  {Uint8Array} ciphertext  The ciphertext input to be decrypted
+     * @param  {Uint8Array} nonce       The nonce (15 bytes)
+     * @param  {Uint8Array} adata       Associated data to sign
+     * @returns {Promise<Uint8Array>}    The ciphertext output
      */
     decrypt: async function(ciphertext, nonce, adata) {
-      //
-      // Consider C as a sequence of 128-bit blocks
-      //
-      const ctTag = ciphertext.subarray(ciphertext.length - tagLength);
-      ciphertext = ciphertext.subarray(0, ciphertext.length - tagLength);
-      const m = ciphertext.length >> 4;
+      if (ciphertext.length < tagLength) throw new Error('Invalid OCB ciphertext');
 
-      //
-      // Key-dependent variables
-      //
-      extendKeyVariables(ciphertext, adata);
-      const { encipher, decipher, mask } = kv;
+      const tag = ciphertext.subarray(-tagLength);
+      ciphertext = ciphertext.subarray(0, -tagLength);
 
-      //
-      // Nonce-dependent and per-encryption variables
-      //
-      // We assume here that tagLength mod 16 == 0.
-      const paddedNonce = util.concatUint8Array([zeroBlock.subarray(0, 15 - nonce.length), one, nonce]);
-      const bottom = paddedNonce[15] & 0b111111;
-      paddedNonce[15] &= 0b11000000;
-      const kTop = encipher(paddedNonce);
-      const stretched = util.concatUint8Array([kTop, xor(kTop.subarray(0, 8), kTop.subarray(1, 9))]);
-      //    Offset_0 = Stretch[1+bottom..128+bottom]
-      const offset = util.shiftRight(stretched.subarray(0 + (bottom >> 3), 17 + (bottom >> 3)), 8 - (bottom & 7)).subarray(1);
-      const checksum = new Uint8Array(16);
-
-      const pt = new Uint8Array(ciphertext.length);
-
-      //
-      // Process any whole blocks
-      //
-      let i;
-      let pos = 0;
-      for (i = 0; i < m; i++) {
-        xorMut(offset, mask[ntz(i + 1)]);
-        pt.set(xorMut(decipher(xor(offset, ciphertext)), offset), pos);
-        xorMut(checksum, pt.subarray(pos));
-
-        ciphertext = ciphertext.subarray(16);
-        pos += 16;
+      const crypted = crypt(decipher, ciphertext, nonce, adata);
+      // if (Tag[1..TAGLEN] == T)
+      if (util.equalsUint8Array(tag, crypted.subarray(-tagLength))) {
+        return crypted.subarray(0, -tagLength);
       }
-
-      //
-      // Process any final partial block and compute raw tag
-      //
-      if (ciphertext.length) {
-        xorMut(offset, mask.x);
-        const padding = encipher(offset);
-        pt.set(xor(ciphertext, padding), pos);
-
-        // Checksum_* = Checksum_m xor (P_* || 1 || new Uint8Array(127-bitlen(P_*)))
-        const xorInput = new Uint8Array(16);
-        xorInput.set(pt.subarray(pos), 0);
-        xorInput[ciphertext.length] = 0b10000000;
-        xorMut(checksum, xorInput);
-        pos += ciphertext.length;
-      }
-      const tag = xorMut(encipher(xorMut(xorMut(checksum, offset), mask.$)), hash(adata));
-
-      //
-      // Check for validity and assemble plaintext
-      //
-      if (!util.equalsUint8Array(ctTag, tag)) {
-        throw new Error('Authentication tag mismatch in OCB ciphertext');
-      }
-      return pt;
+      throw new Error('Authentication tag mismatch in OCB ciphertext');
     }
   };
 }

--- a/src/crypto/ocb.js
+++ b/src/crypto/ocb.js
@@ -303,5 +303,6 @@ OCB.getNonce = function(iv, chunkIndex) {
 
 OCB.blockLength = blockLength;
 OCB.ivLength = ivLength;
+OCB.tagLength = tagLength;
 
 export default OCB;

--- a/src/crypto/ocb.js
+++ b/src/crypto/ocb.js
@@ -79,237 +79,247 @@ function double(S) {
 const zeros_16 = zeros(16);
 const one = new Uint8Array([1]);
 
-function constructKeyVariables(cipher, key, text, adata) {
-  const aes = new ciphers[cipher](key);
-  const encipher = aes.encrypt.bind(aes);
-  const decipher = aes.decrypt.bind(aes);
-
-  const L_x = encipher(zeros_16);
-  const L_$ = double(L_x);
-  const L = [];
-  L[0] = double(L_$);
-
-  const max_ntz = util.nbits(Math.max(text.length, adata.length) >> 4) - 1;
-  for (let i = 1; i <= max_ntz; i++) {
-    L[i] = double(L[i - 1]);
+class OCB {
+  /**
+   * Class to en/decrypt using OCB mode.
+   * @param  {String}     cipher      The symmetric cipher algorithm to use e.g. 'aes128'
+   * @param  {Uint8Array} key         The encryption key
+   */
+  constructor(cipher, key) {
+    this.max_ntz = 0;
+    this.constructKeyVariables(cipher, key);
   }
 
-  L.x = L_x;
-  L.$ = L_$;
+  constructKeyVariables(cipher, key) {
+    const aes = new ciphers[cipher](key);
+    const encipher = aes.encrypt.bind(aes);
+    const decipher = aes.decrypt.bind(aes);
 
-  return { encipher, decipher, L };
+    const L_x = encipher(zeros_16);
+    const L_$ = double(L_x);
+    const L = [];
+    L[0] = double(L_$);
+
+
+    L.x = L_x;
+    L.$ = L_$;
+
+    this.kv = { encipher, decipher, L };
+  }
+
+  extendKeyVariables(text, adata) {
+    const { L } = this.kv;
+    const max_ntz = util.nbits(Math.max(text.length, adata.length) >> 4) - 1;
+    for (let i = this.max_ntz + 1; i <= max_ntz; i++) {
+      L[i] = double(L[i - 1]);
+    }
+    this.max_ntz = max_ntz;
+  }
+
+  hash(adata) {
+    if (!adata.length) {
+      // Fast path
+      return zeros_16;
+    }
+
+    const { encipher, L } = this.kv;
+
+    //
+    // Consider A as a sequence of 128-bit blocks
+    //
+    const m = adata.length >> 4;
+
+    const offset = zeros(16);
+    const sum = zeros(16);
+    for (let i = 0; i < m; i++) {
+      set_xor(offset, L[ntz(i + 1)]);
+      set_xor(sum, encipher(xor(offset, adata)));
+      adata = adata.subarray(16);
+    }
+
+    //
+    // Process any final partial block; compute final hash value
+    //
+    if (adata.length) {
+      set_xor(offset, L.x);
+
+      const cipherInput = zeros(16);
+      cipherInput.set(adata, 0);
+      cipherInput[adata.length] = 0b10000000;
+      set_xor(cipherInput, offset);
+
+      set_xor(sum, encipher(cipherInput));
+    }
+
+    return sum;
+  }
+
+
+  /**
+   * Encrypt plaintext input.
+   * @param  {Uint8Array} plaintext   The cleartext input to be encrypted
+   * @param  {Uint8Array} nonce       The nonce (15 bytes)
+   * @param  {Uint8Array} adata       Associated data to sign
+   * @returns {Promise<Uint8Array>}    The ciphertext output
+   */
+  async encrypt(plaintext, nonce, adata) {
+    //
+    // Consider P as a sequence of 128-bit blocks
+    //
+    const m = plaintext.length >> 4;
+
+    //
+    // Key-dependent variables
+    //
+    this.extendKeyVariables(plaintext, adata);
+    const { encipher, L } = this.kv;
+
+    //
+    // Nonce-dependent and per-encryption variables
+    //
+    // We assume here that TAGLEN mod 128 == 0 (tagLength === 16).
+    const Nonce = concat(zeros_16.subarray(0, 15 - nonce.length), one, nonce);
+    const bottom = Nonce[15] & 0b111111;
+    Nonce[15] &= 0b11000000;
+    const Ktop = encipher(Nonce);
+    const Stretch = concat(Ktop, xor(Ktop.subarray(0, 8), Ktop.subarray(1, 9)));
+    //    Offset_0 = Stretch[1+bottom..128+bottom]
+    const offset = shiftRight(Stretch.subarray(0 + (bottom >> 3), 17 + (bottom >> 3)), 8 - (bottom & 7)).subarray(1);
+    const checksum = zeros(16);
+
+    const C = new Uint8Array(plaintext.length + tagLength);
+
+    //
+    // Process any whole blocks
+    //
+    let i;
+    let pos = 0;
+    for (i = 0; i < m; i++) {
+      set_xor(offset, L[ntz(i + 1)]);
+      C.set(set_xor(encipher(xor(offset, plaintext)), offset), pos);
+      set_xor(checksum, plaintext);
+
+      plaintext = plaintext.subarray(16);
+      pos += 16;
+    }
+
+    //
+    // Process any final partial block and compute raw tag
+    //
+    if (plaintext.length) {
+      set_xor(offset, L.x);
+      const Pad = encipher(offset);
+      C.set(xor(plaintext, Pad), pos);
+
+      // Checksum_* = Checksum_m xor (P_* || 1 || zeros(127-bitlen(P_*)))
+      const xorInput = zeros(16);
+      xorInput.set(plaintext, 0);
+      xorInput[plaintext.length] = 0b10000000;
+      set_xor(checksum, xorInput);
+      pos += plaintext.length;
+    }
+    const Tag = set_xor(encipher(set_xor(set_xor(checksum, offset), L.$)), this.hash(adata));
+
+    //
+    // Assemble ciphertext
+    //
+    C.set(Tag, pos);
+    return C;
+  }
+
+
+  /**
+   * Decrypt ciphertext input.
+   * @param  {Uint8Array} ciphertext   The ciphertext input to be decrypted
+   * @param  {Uint8Array} nonce        The nonce (15 bytes)
+   * @param  {Uint8Array} adata        Associated data to verify
+   * @returns {Promise<Uint8Array>}     The plaintext output
+   */
+  async decrypt(ciphertext, nonce, adata) {
+    //
+    // Consider C as a sequence of 128-bit blocks
+    //
+    const T = ciphertext.subarray(ciphertext.length - tagLength);
+    ciphertext = ciphertext.subarray(0, ciphertext.length - tagLength);
+    const m = ciphertext.length >> 4;
+
+    //
+    // Key-dependent variables
+    //
+    this.extendKeyVariables(ciphertext, adata);
+    const { encipher, decipher, L } = this.kv;
+
+    //
+    // Nonce-dependent and per-encryption variables
+    //
+    // We assume here that TAGLEN mod 128 == 0 (tagLength === 16).
+    const Nonce = concat(zeros_16.subarray(0, 15 - nonce.length), one, nonce);
+    const bottom = Nonce[15] & 0b111111;
+    Nonce[15] &= 0b11000000;
+    const Ktop = encipher(Nonce);
+    const Stretch = concat(Ktop, xor(Ktop.subarray(0, 8), Ktop.subarray(1, 9)));
+    //    Offset_0 = Stretch[1+bottom..128+bottom]
+    const offset = shiftRight(Stretch.subarray(0 + (bottom >> 3), 17 + (bottom >> 3)), 8 - (bottom & 7)).subarray(1);
+    const checksum = zeros(16);
+
+    const P = new Uint8Array(ciphertext.length);
+
+    //
+    // Process any whole blocks
+    //
+    let i;
+    let pos = 0;
+    for (i = 0; i < m; i++) {
+      set_xor(offset, L[ntz(i + 1)]);
+      P.set(set_xor(decipher(xor(offset, ciphertext)), offset), pos);
+      set_xor(checksum, P.subarray(pos));
+
+      ciphertext = ciphertext.subarray(16);
+      pos += 16;
+    }
+
+    //
+    // Process any final partial block and compute raw tag
+    //
+    if (ciphertext.length) {
+      set_xor(offset, L.x);
+      const Pad = encipher(offset);
+      P.set(xor(ciphertext, Pad), pos);
+
+      // Checksum_* = Checksum_m xor (P_* || 1 || zeros(127-bitlen(P_*)))
+      const xorInput = zeros(16);
+      xorInput.set(P.subarray(pos), 0);
+      xorInput[ciphertext.length] = 0b10000000;
+      set_xor(checksum, xorInput);
+      pos += ciphertext.length;
+    }
+    const Tag = set_xor(encipher(set_xor(set_xor(checksum, offset), L.$)), this.hash(adata));
+
+    //
+    // Check for validity and assemble plaintext
+    //
+    if (!util.equalsUint8Array(Tag, T)) {
+      throw new Error('Authentication tag mismatch in OCB ciphertext');
+    }
+    return P;
+  }
 }
 
-function hash(kv, key, adata) {
-  if (!adata.length) {
-    // Fast path
-    return zeros_16;
-  }
-
-  const { encipher, L } = kv;
-
-  //
-  // Consider A as a sequence of 128-bit blocks
-  //
-  const m = adata.length >> 4;
-
-  const offset = zeros(16);
-  const sum = zeros(16);
-  for (let i = 0; i < m; i++) {
-    set_xor(offset, L[ntz(i + 1)]);
-    set_xor(sum, encipher(xor(offset, adata)));
-    adata = adata.subarray(16);
-  }
-
-  //
-  // Process any final partial block; compute final hash value
-  //
-  if (adata.length) {
-    set_xor(offset, L.x);
-
-    const cipherInput = zeros(16);
-    cipherInput.set(adata, 0);
-    cipherInput[adata.length] = 0b10000000;
-    set_xor(cipherInput, offset);
-
-    set_xor(sum, encipher(cipherInput));
-  }
-
-  return sum;
-}
-
-
-/**
- * Encrypt plaintext input.
- * @param  {String}     cipher      The symmetric cipher algorithm to use e.g. 'aes128'
- * @param  {Uint8Array} plaintext   The cleartext input to be encrypted
- * @param  {Uint8Array} key         The encryption key
- * @param  {Uint8Array} nonce       The nonce (15 bytes)
- * @param  {Uint8Array} adata       Associated data to sign
- * @returns {Promise<Uint8Array>}    The ciphertext output
- */
-async function encrypt(cipher, plaintext, key, nonce, adata) {
-  //
-  // Consider P as a sequence of 128-bit blocks
-  //
-  const m = plaintext.length >> 4;
-
-  //
-  // Key-dependent variables
-  //
-  const kv = constructKeyVariables(cipher, key, plaintext, adata);
-  const { encipher, L } = kv;
-
-  //
-  // Nonce-dependent and per-encryption variables
-  //
-  // We assume here that TAGLEN mod 128 == 0 (tagLength === 16).
-  const Nonce = concat(zeros_16.subarray(0, 15 - nonce.length), one, nonce);
-  const bottom = Nonce[15] & 0b111111;
-  Nonce[15] &= 0b11000000;
-  const Ktop = encipher(Nonce);
-  const Stretch = concat(Ktop, xor(Ktop.subarray(0, 8), Ktop.subarray(1, 9)));
-  //    Offset_0 = Stretch[1+bottom..128+bottom]
-  const offset = shiftRight(Stretch.subarray(0 + (bottom >> 3), 17 + (bottom >> 3)), 8 - (bottom & 7)).subarray(1);
-  const checksum = zeros(16);
-
-  const C = new Uint8Array(plaintext.length + tagLength);
-
-  //
-  // Process any whole blocks
-  //
-  let i;
-  let pos = 0;
-  for (i = 0; i < m; i++) {
-    set_xor(offset, L[ntz(i + 1)]);
-    C.set(set_xor(encipher(xor(offset, plaintext)), offset), pos);
-    set_xor(checksum, plaintext);
-
-    plaintext = plaintext.subarray(16);
-    pos += 16;
-  }
-
-  //
-  // Process any final partial block and compute raw tag
-  //
-  if (plaintext.length) {
-    set_xor(offset, L.x);
-    const Pad = encipher(offset);
-    C.set(xor(plaintext, Pad), pos);
-
-    // Checksum_* = Checksum_m xor (P_* || 1 || zeros(127-bitlen(P_*)))
-    const xorInput = zeros(16);
-    xorInput.set(plaintext, 0);
-    xorInput[plaintext.length] = 0b10000000;
-    set_xor(checksum, xorInput);
-    pos += plaintext.length;
-  }
-  const Tag = set_xor(encipher(set_xor(set_xor(checksum, offset), L.$)), hash(kv, key, adata));
-
-  //
-  // Assemble ciphertext
-  //
-  C.set(Tag, pos);
-  return C;
-}
-
-
-/**
- * Decrypt ciphertext input.
- * @param  {String}     cipher       The symmetric cipher algorithm to use e.g. 'aes128'
- * @param  {Uint8Array} ciphertext   The ciphertext input to be decrypted
- * @param  {Uint8Array} key          The encryption key
- * @param  {Uint8Array} nonce        The nonce (15 bytes)
- * @param  {Uint8Array} adata        Associated data to verify
- * @returns {Promise<Uint8Array>}     The plaintext output
- */
-async function decrypt(cipher, ciphertext, key, nonce, adata) {
-  //
-  // Consider C as a sequence of 128-bit blocks
-  //
-  const T = ciphertext.subarray(ciphertext.length - tagLength);
-  ciphertext = ciphertext.subarray(0, ciphertext.length - tagLength);
-  const m = ciphertext.length >> 4;
-
-  //
-  // Key-dependent variables
-  //
-  const kv = constructKeyVariables(cipher, key, ciphertext, adata);
-  const { encipher, decipher, L } = kv;
-
-  //
-  // Nonce-dependent and per-encryption variables
-  //
-  // We assume here that TAGLEN mod 128 == 0 (tagLength === 16).
-  const Nonce = concat(zeros_16.subarray(0, 15 - nonce.length), one, nonce);
-  const bottom = Nonce[15] & 0b111111;
-  Nonce[15] &= 0b11000000;
-  const Ktop = encipher(Nonce);
-  const Stretch = concat(Ktop, xor(Ktop.subarray(0, 8), Ktop.subarray(1, 9)));
-  //    Offset_0 = Stretch[1+bottom..128+bottom]
-  const offset = shiftRight(Stretch.subarray(0 + (bottom >> 3), 17 + (bottom >> 3)), 8 - (bottom & 7)).subarray(1);
-  const checksum = zeros(16);
-
-  const P = new Uint8Array(ciphertext.length);
-
-  //
-  // Process any whole blocks
-  //
-  let i;
-  let pos = 0;
-  for (i = 0; i < m; i++) {
-    set_xor(offset, L[ntz(i + 1)]);
-    P.set(set_xor(decipher(xor(offset, ciphertext)), offset), pos);
-    set_xor(checksum, P.subarray(pos));
-
-    ciphertext = ciphertext.subarray(16);
-    pos += 16;
-  }
-
-  //
-  // Process any final partial block and compute raw tag
-  //
-  if (ciphertext.length) {
-    set_xor(offset, L.x);
-    const Pad = encipher(offset);
-    P.set(xor(ciphertext, Pad), pos);
-
-    // Checksum_* = Checksum_m xor (P_* || 1 || zeros(127-bitlen(P_*)))
-    const xorInput = zeros(16);
-    xorInput.set(P.subarray(pos), 0);
-    xorInput[ciphertext.length] = 0b10000000;
-    set_xor(checksum, xorInput);
-    pos += ciphertext.length;
-  }
-  const Tag = set_xor(encipher(set_xor(set_xor(checksum, offset), L.$)), hash(kv, key, adata));
-
-  //
-  // Check for validity and assemble plaintext
-  //
-  if (!util.equalsUint8Array(Tag, T)) {
-    throw new Error('Authentication tag mismatch in OCB ciphertext');
-  }
-  return P;
-}
 
 /**
  * Get OCB nonce as defined by {@link https://tools.ietf.org/html/draft-ietf-openpgp-rfc4880bis-04#section-5.16.2|RFC4880bis-04, section 5.16.2}.
  * @param  {Uint8Array} iv           The initialization vector (15 bytes)
  * @param  {Uint8Array} chunkIndex   The chunk index (8 bytes)
  */
-function getNonce(iv, chunkIndex) {
+OCB.getNonce = function(iv, chunkIndex) {
   const nonce = iv.slice();
   for (let i = 0; i < chunkIndex.length; i++) {
     nonce[7 + i] ^= chunkIndex[i];
   }
   return nonce;
-}
-
-
-export default {
-  blockLength,
-  ivLength,
-  encrypt,
-  decrypt,
-  getNonce
 };
+
+OCB.blockLength = blockLength;
+OCB.ivLength = ivLength;
+
+export default OCB;

--- a/src/crypto/public_key/dsa.js
+++ b/src/crypto/public_key/dsa.js
@@ -67,9 +67,8 @@ export default {
     // truncated) hash function result is treated as a number and used
     // directly in the DSA signature algorithm.
     const h = new BN(
-      util.str_to_Uint8Array(
-        util.getLeftNBits(
-          util.Uint8Array_to_str(hash.digest(hash_algo, m)), q.bitLength())));
+      util.getLeftNBits(
+        hash.digest(hash_algo, m), q.bitLength()));
     // FIPS-186-4, section 4.6:
     // The values of r and s shall be checked to determine if r = 0 or s = 0.
     // If either r = 0 or s = 0, a new value of k shall be generated, and the
@@ -116,9 +115,8 @@ export default {
     const redp = new BN.red(p);
     const redq = new BN.red(q);
     const h = new BN(
-      util.str_to_Uint8Array(
-        util.getLeftNBits(
-          util.Uint8Array_to_str(hash.digest(hash_algo, m)), q.bitLength())));
+      util.getLeftNBits(
+        hash.digest(hash_algo, m), q.bitLength()));
     const w = s.toRed(redq).redInvm(); // s**-1 mod q
     if (zero.cmp(w) === 0) {
       util.print_debug("invalid DSA Signature");

--- a/src/crypto/public_key/elliptic/curves.js
+++ b/src/crypto/public_key/elliptic/curves.js
@@ -182,14 +182,14 @@ Curve.prototype.keyFromPublic = function (pub) {
 
 Curve.prototype.genKeyPair = async function () {
   let keyPair;
-  if (webCrypto && this.web) {
+  if (this.web && util.getWebCrypto()) {
     // If browser doesn't support a curve, we'll catch it
     try {
       keyPair = await webGenKeyPair(this.name);
     } catch (err) {
       util.print_debug("Browser did not support signing: " + err.message);
     }
-  } else if (nodeCrypto && this.node) {
+  } else if (this.node && util.getNodeCrypto()) {
     keyPair = await nodeGenKeyPair(this.name);
   }
 

--- a/src/crypto/public_key/elliptic/ecdh.js
+++ b/src/crypto/public_key/elliptic/ecdh.js
@@ -46,7 +46,7 @@ function buildEcdhParam(public_algo, oid, cipher_algo, hash_algo, fingerprint) {
     new Uint8Array([public_algo]),
     kdf_params.write(),
     util.str_to_Uint8Array("Anonymous Sender    "),
-    fingerprint
+    fingerprint.subarray(0, 20)
   ]);
 }
 
@@ -73,7 +73,6 @@ function kdf(hash_algo, X, length, param) {
  * @async
  */
 async function encrypt(oid, cipher_algo, hash_algo, m, Q, fingerprint) {
-  fingerprint = util.hex_to_Uint8Array(fingerprint);
   const curve = new Curve(oid);
   const param = buildEcdhParam(enums.publicKey.ecdh, oid, cipher_algo, hash_algo, fingerprint);
   cipher_algo = enums.read(enums.symmetric, cipher_algo);
@@ -102,7 +101,6 @@ async function encrypt(oid, cipher_algo, hash_algo, m, Q, fingerprint) {
  * @async
  */
 async function decrypt(oid, cipher_algo, hash_algo, V, C, d, fingerprint) {
-  fingerprint = util.hex_to_Uint8Array(fingerprint);
   const curve = new Curve(oid);
   const param = buildEcdhParam(enums.publicKey.ecdh, oid, cipher_algo, hash_algo, fingerprint);
   cipher_algo = enums.read(enums.symmetric, cipher_algo);

--- a/src/crypto/public_key/elliptic/key.js
+++ b/src/crypto/public_key/elliptic/key.js
@@ -45,7 +45,7 @@ function KeyPair(curve, options) {
 }
 
 KeyPair.prototype.sign = async function (message, hash_algo) {
-  if (webCrypto && this.curve.web) {
+  if (this.curve.web && util.getWebCrypto()) {
     // If browser doesn't support a curve, we'll catch it
     try {
       // need to await to make sure browser succeeds
@@ -54,7 +54,7 @@ KeyPair.prototype.sign = async function (message, hash_algo) {
     } catch (err) {
       util.print_debug("Browser did not support signing: " + err.message);
     }
-  } else if (nodeCrypto && this.curve.node) {
+  } else if (this.curve.node && util.getNodeCrypto()) {
     return nodeSign(this.curve, hash_algo, message, this.keyPair);
   }
   const digest = (typeof hash_algo === 'undefined') ? message : hash.digest(hash_algo, message);
@@ -62,7 +62,7 @@ KeyPair.prototype.sign = async function (message, hash_algo) {
 };
 
 KeyPair.prototype.verify = async function (message, signature, hash_algo) {
-  if (webCrypto && this.curve.web) {
+  if (this.curve.web && util.getWebCrypto()) {
     // If browser doesn't support a curve, we'll catch it
     try {
       // need to await to make sure browser succeeds
@@ -71,7 +71,7 @@ KeyPair.prototype.verify = async function (message, signature, hash_algo) {
     } catch (err) {
       util.print_debug("Browser did not support signing: " + err.message);
     }
-  } else if (nodeCrypto && this.curve.node) {
+  } else if (this.curve.node && util.getNodeCrypto()) {
     return nodeVerify(this.curve, hash_algo, signature, message, this.keyPair.getPublic());
   }
   const digest = (typeof hash_algo === 'undefined') ? message : hash.digest(hash_algo, message);

--- a/src/encoding/armor.js
+++ b/src/encoding/armor.js
@@ -347,7 +347,7 @@ function armor(messagetype, body, partindex, parttotal) {
     case enums.armor.signed:
       result.push("\r\n-----BEGIN PGP SIGNED MESSAGE-----\r\n");
       result.push("Hash: " + body.hash + "\r\n\r\n");
-      result.push(body.text.replace(/\n-/g, "\n- -"));
+      result.push(body.text.replace(/^-/mg, "- -"));
       result.push("\r\n-----BEGIN PGP SIGNATURE-----\r\n");
       result.push(addheader());
       result.push(base64.encode(body.data));

--- a/src/enums.js
+++ b/src/enums.js
@@ -212,7 +212,9 @@ export default {
     /** Text data 't' */
     text: 't'.charCodeAt(),
     /** Utf8 data 'u' */
-    utf8: 'u'.charCodeAt()
+    utf8: 'u'.charCodeAt(),
+    /** MIME message body part 'm' */
+    mime: 'm'.charCodeAt()
   },
 
 

--- a/src/enums.js
+++ b/src/enums.js
@@ -419,6 +419,21 @@ export default {
     signature: 6
   },
 
+  /** {@link https://tools.ietf.org/html/draft-ietf-openpgp-rfc4880bis-04#section-5.2.3.25|RFC4880bis-04, section 5.2.3.25}
+   * @enum {Integer}
+   * @readonly
+   */
+  features: {
+    /** 0x01 - Modification Detection (packets 18 and 19) */
+    modification_detection: 1,
+    /** 0x02 - AEAD Encrypted Data Packet (packet 20) and version 5
+     *         Symmetric-Key Encrypted Session Key Packets (packet 3) */
+    aead: 2,
+    /** 0x04 - Version 5 Public-Key Packet format and corresponding new
+      *        fingerprint format */
+    v5_keys: 4
+  },
+
   /** Asserts validity and converts from string/integer to integer. */
   write: function(type, e) {
     if (typeof e === 'number') {

--- a/src/enums.js
+++ b/src/enums.js
@@ -366,7 +366,8 @@ export default {
     reason_for_revocation: 29,
     features: 30,
     signature_target: 31,
-    embedded_signature: 32
+    embedded_signature: 32,
+    preferred_aead_algorithms: 34
   },
 
   /** Key flags

--- a/src/enums.js
+++ b/src/enums.js
@@ -88,7 +88,7 @@ export default {
     gnu: 101
   },
 
-  /** {@link https://tools.ietf.org/html/rfc4880#section-9.1|RFC4880, section 9.1}
+  /** {@link https://tools.ietf.org/html/draft-ietf-openpgp-rfc4880bis-04#section-9.1|RFC4880bis-04, section 9.1}
    * @enum {Integer}
    * @readonly
    */
@@ -109,7 +109,11 @@ export default {
     ecdsa: 19,
     /** EdDSA (Sign only)
      * [{@link https://tools.ietf.org/html/draft-koch-eddsa-for-openpgp-04|Draft RFC}] */
-    eddsa: 22
+    eddsa: 22,
+    /** Reserved for AEDH */
+    aedh: 23,
+    /** Reserved for AEDSA */
+    aedsa: 24
   },
 
   /** {@link https://tools.ietf.org/html/rfc4880#section-9.2|RFC4880, section 9.2}

--- a/src/enums.js
+++ b/src/enums.js
@@ -167,6 +167,16 @@ export default {
     'SHA-512': 10
   },
 
+  /** {@link https://tools.ietf.org/html/draft-ietf-openpgp-rfc4880bis-04#section-9.6|RFC4880bis-04, section 9.6}
+   * @enum {Integer}
+   * @readonly
+   */
+  aead: {
+    eax: 1,
+    ocb: 2,
+    gcm: 100 // Private algorithm
+  },
+
   /** A list of packet types and numeric tags associated with them.
    * @enum {Integer}
    * @readonly

--- a/src/enums.js
+++ b/src/enums.js
@@ -373,6 +373,7 @@ export default {
     features: 30,
     signature_target: 31,
     embedded_signature: 32,
+    issuer_fingerprint: 33,
     preferred_aead_algorithms: 34
   },
 

--- a/src/key.js
+++ b/src/key.js
@@ -468,7 +468,7 @@ Key.prototype.getExpirationTime = async function() {
   if (this.primaryKey.version === 3) {
     return getExpirationTime(this.primaryKey);
   }
-  if (this.primaryKey.version === 4) {
+  if (this.primaryKey.version >= 4) {
     const primaryUser = await this.getPrimaryUser(null);
     const selfCert = primaryUser.selfCertification;
     const keyExpiry = getExpirationTime(this.primaryKey, selfCert);
@@ -1383,7 +1383,7 @@ function getExpirationTime(keyPacket, signature) {
     expirationTime = keyPacket.created.getTime() + keyPacket.expirationTimeV3*24*3600*1000;
   }
   // check V4 expiration time
-  if (keyPacket.version === 4 && signature.keyNeverExpires === false) {
+  if (keyPacket.version >= 4 && signature.keyNeverExpires === false) {
     expirationTime = keyPacket.created.getTime() + signature.keyExpirationTime*1000;
   }
   return expirationTime ? new Date(expirationTime) : Infinity;

--- a/src/key.js
+++ b/src/key.js
@@ -1278,8 +1278,13 @@ async function wrapKeyObject(secretKeyPacket, secretSubkeyPackets, options) {
       signaturePacket.isPrimaryUserID = true;
     }
     if (config.integrity_protect) {
-      signaturePacket.features = [];
-      signaturePacket.features.push(1); // Modification Detection
+      signaturePacket.features = [0];
+      signaturePacket.features[0] |= enums.features.modification_detection;
+    }
+    if (config.aead_protect === 'draft04') {
+      signaturePacket.features || (signaturePacket.features = [0]);
+      signaturePacket.features[0] |= enums.features.aead;
+      signaturePacket.features[0] |= enums.features.v5_keys;
     }
     if (options.keyExpirationTime > 0) {
       signaturePacket.keyExpirationTime = options.keyExpirationTime;

--- a/src/key.js
+++ b/src/key.js
@@ -1261,7 +1261,7 @@ async function wrapKeyObject(secretKeyPacket, secretSubkeyPackets, options) {
     signaturePacket.preferredSymmetricAlgorithms.push(enums.symmetric.aes192);
     signaturePacket.preferredSymmetricAlgorithms.push(enums.symmetric.cast5);
     signaturePacket.preferredSymmetricAlgorithms.push(enums.symmetric.tripledes);
-    if (config.aead_protect === 'draft04') {
+    if (config.aead_protect && config.aead_protect_version === 4) {
       signaturePacket.preferredAeadAlgorithms = [];
       signaturePacket.preferredAeadAlgorithms.push(enums.aead.eax);
       signaturePacket.preferredAeadAlgorithms.push(enums.aead.ocb);
@@ -1281,7 +1281,7 @@ async function wrapKeyObject(secretKeyPacket, secretSubkeyPackets, options) {
       signaturePacket.features = [0];
       signaturePacket.features[0] |= enums.features.modification_detection;
     }
-    if (config.aead_protect === 'draft04') {
+    if (config.aead_protect && config.aead_protect_version === 4) {
       signaturePacket.features || (signaturePacket.features = [0]);
       signaturePacket.features[0] |= enums.features.aead;
       signaturePacket.features[0] |= enums.features.v5_keys;

--- a/src/message.js
+++ b/src/message.js
@@ -157,7 +157,9 @@ Message.prototype.decryptSessionKeys = async function(privateKeys, passwords) {
         try {
           await keyPacket.decrypt(password);
           keyPackets.push(keyPacket);
-        } catch (err) {}
+        } catch (err) {
+          util.print_debug_error(err);
+        }
       }));
     }));
   } else if (privateKeys) {
@@ -180,7 +182,9 @@ Message.prototype.decryptSessionKeys = async function(privateKeys, passwords) {
         try {
           await keyPacket.decrypt(privateKeyPacket);
           keyPackets.push(keyPacket);
-        } catch (err) {}
+        } catch (err) {
+          util.print_debug_error(err);
+        }
       }));
     }));
   } else {

--- a/src/message.js
+++ b/src/message.js
@@ -36,7 +36,7 @@ import enums from './enums';
 import util from './util';
 import packet from './packet';
 import { Signature } from './signature';
-import { getPreferredHashAlgo, getPreferredSymAlgo } from './key';
+import { getPreferredHashAlgo, getPreferredSymAlgo, getPreferredAeadAlgo } from './key';
 
 
 /**
@@ -252,6 +252,7 @@ Message.prototype.getText = function() {
  */
 Message.prototype.encrypt = async function(keys, passwords, sessionKey, wildcard=false, date=new Date()) {
   let symAlgo;
+  let aeadAlgo;
   let symEncryptedPacket;
 
   if (sessionKey) {
@@ -259,11 +260,14 @@ Message.prototype.encrypt = async function(keys, passwords, sessionKey, wildcard
       throw new Error('Invalid session key for encryption.');
     }
     symAlgo = sessionKey.algorithm;
+    aeadAlgo = sessionKey.aeadAlgorithm || config.aead_mode;
     sessionKey = sessionKey.data;
   } else if (keys && keys.length) {
     symAlgo = enums.read(enums.symmetric, await getPreferredSymAlgo(keys));
+    aeadAlgo = enums.read(enums.aead, await getPreferredAeadAlgo(keys));
   } else if (passwords && passwords.length) {
     symAlgo = enums.read(enums.symmetric, config.encryption_cipher);
+    aeadAlgo = enums.read(enums.aead, config.aead_mode);
   } else {
     throw new Error('No keys, passwords, or session key provided.');
   }
@@ -272,10 +276,11 @@ Message.prototype.encrypt = async function(keys, passwords, sessionKey, wildcard
     sessionKey = await crypto.generateSessionKey(symAlgo);
   }
 
-  const msg = await encryptSessionKey(sessionKey, symAlgo, keys, passwords, wildcard, date);
+  const msg = await encryptSessionKey(sessionKey, symAlgo, aeadAlgo, keys, passwords, wildcard, date);
 
   if (config.aead_protect) {
     symEncryptedPacket = new packet.SymEncryptedAEADProtected();
+    symEncryptedPacket.aeadAlgorithm = aeadAlgo;
   } else if (config.integrity_protect) {
     symEncryptedPacket = new packet.SymEncryptedIntegrityProtected();
   } else {
@@ -291,7 +296,8 @@ Message.prototype.encrypt = async function(keys, passwords, sessionKey, wildcard
     message: msg,
     sessionKey: {
       data: sessionKey,
-      algorithm: symAlgo
+      algorithm: symAlgo,
+      aeadAlgorithm: aeadAlgo
     }
   };
 };
@@ -300,6 +306,7 @@ Message.prototype.encrypt = async function(keys, passwords, sessionKey, wildcard
  * Encrypt a session key either with public keys, passwords, or both at once.
  * @param  {Uint8Array} sessionKey     session key for encryption
  * @param  {String} symAlgo            session key algorithm
+ * @param  {String} aeadAlgo           (optional) aead algorithm, e.g. 'eax' or 'ocb'
  * @param  {Array<Key>} publicKeys     (optional) public key(s) for message encryption
  * @param  {Array<String>} passwords   (optional) for message encryption
  * @param  {Boolean} wildcard          (optional) use a key ID of 0 instead of the public key IDs
@@ -307,7 +314,7 @@ Message.prototype.encrypt = async function(keys, passwords, sessionKey, wildcard
  * @returns {Promise<Message>}          new message with encrypted content
  * @async
  */
-export async function encryptSessionKey(sessionKey, symAlgo, publicKeys, passwords, wildcard=false, date=new Date()) {
+export async function encryptSessionKey(sessionKey, symAlgo, aeadAlgo, publicKeys, passwords, wildcard=false, date=new Date()) {
   const packetlist = new packet.List();
 
   if (publicKeys) {
@@ -340,10 +347,13 @@ export async function encryptSessionKey(sessionKey, symAlgo, publicKeys, passwor
 
     const sum = (accumulator, currentValue) => accumulator + currentValue;
 
-    const encryptPassword = async function(sessionKey, symAlgo, password) {
+    const encryptPassword = async function(sessionKey, symAlgo, aeadAlgo, password) {
       const symEncryptedSessionKeyPacket = new packet.SymEncryptedSessionKey();
       symEncryptedSessionKeyPacket.sessionKey = sessionKey;
       symEncryptedSessionKeyPacket.sessionKeyAlgorithm = symAlgo;
+      if (aeadAlgo) {
+        symEncryptedSessionKeyPacket.aeadAlgorithm = aeadAlgo;
+      }
       await symEncryptedSessionKeyPacket.encrypt(password);
 
       if (config.password_collision_check) {
@@ -357,7 +367,7 @@ export async function encryptSessionKey(sessionKey, symAlgo, publicKeys, passwor
       return symEncryptedSessionKeyPacket;
     };
 
-    const results = await Promise.all(passwords.map(pwd => encryptPassword(sessionKey, symAlgo, pwd)));
+    const results = await Promise.all(passwords.map(pwd => encryptPassword(sessionKey, symAlgo, aeadAlgo, pwd)));
     packetlist.concat(results);
   }
 

--- a/src/message.js
+++ b/src/message.js
@@ -652,13 +652,14 @@ export function read(input) {
  * @param {String} text
  * @param {String} filename (optional)
  * @param {Date} date (optional)
+ * @param {utf8|binary|text|mime} type (optional) data packet type
  * @returns {module:message.Message} new message object
  * @static
  */
-export function fromText(text, filename, date=new Date()) {
+export function fromText(text, filename, date=new Date(), type='utf8') {
   const literalDataPacket = new packet.Literal(date);
   // text will be converted to UTF8
-  literalDataPacket.setText(text);
+  literalDataPacket.setText(text, type);
   if (filename !== undefined) {
     literalDataPacket.setFilename(filename);
   }
@@ -672,19 +673,17 @@ export function fromText(text, filename, date=new Date()) {
  * @param {Uint8Array} bytes
  * @param {String} filename (optional)
  * @param {Date} date (optional)
+ * @param {utf8|binary|text|mime} type (optional) data packet type
  * @returns {module:message.Message} new message object
  * @static
  */
-export function fromBinary(bytes, filename, date=new Date()) {
+export function fromBinary(bytes, filename, date=new Date(), type='binary') {
   if (!util.isUint8Array(bytes)) {
     throw new Error('Data must be in the form of a Uint8Array');
   }
 
   const literalDataPacket = new packet.Literal(date);
-  if (filename) {
-    literalDataPacket.setFilename(filename);
-  }
-  literalDataPacket.setBytes(bytes, enums.read(enums.literal, enums.literal.binary));
+  literalDataPacket.setBytes(bytes, type);
   if (filename !== undefined) {
     literalDataPacket.setFilename(filename);
   }

--- a/src/message.js
+++ b/src/message.js
@@ -36,7 +36,7 @@ import enums from './enums';
 import util from './util';
 import packet from './packet';
 import { Signature } from './signature';
-import { getPreferredHashAlgo, getPreferredSymAlgo, getPreferredAeadAlgo } from './key';
+import { getPreferredHashAlgo, getPreferredAlgo, isAeadSupported } from './key';
 
 
 /**
@@ -263,10 +263,9 @@ Message.prototype.encrypt = async function(keys, passwords, sessionKey, wildcard
     aeadAlgo = sessionKey.aeadAlgorithm;
     sessionKey = sessionKey.data;
   } else if (keys && keys.length) {
-    symAlgo = enums.read(enums.symmetric, await getPreferredSymAlgo(keys, date));
-    aeadAlgo = await getPreferredAeadAlgo(keys, date);
-    if (aeadAlgo) {
-      aeadAlgo = enums.read(enums.aead, aeadAlgo);
+    symAlgo = enums.read(enums.symmetric, await getPreferredAlgo('symmetric', keys, date));
+    if (await isAeadSupported(keys, date)) {
+      aeadAlgo = enums.read(enums.aead, await getPreferredAlgo('aead', keys, date));
     }
   } else if (passwords && passwords.length) {
     symAlgo = enums.read(enums.symmetric, config.encryption_cipher);

--- a/src/openpgp.js
+++ b/src/openpgp.js
@@ -568,7 +568,7 @@ function parseMessage(message, format) {
  */
 function onError(message, error) {
   // log the stack trace
-  if (config.debug) { console.error(error.stack); }
+  util.print_debug_error(error);
 
   // update error message
   error.message = message + ': ' + error.message;

--- a/src/openpgp.js
+++ b/src/openpgp.js
@@ -395,6 +395,7 @@ export function verify({ message, publicKeys, signature=null, date=new Date() })
  *   or passwords must be specified.
  * @param  {Uint8Array} data                  the session key to be encrypted e.g. 16 random bytes (for aes128)
  * @param  {String} algorithm                 algorithm of the symmetric session key e.g. 'aes128' or 'aes256'
+ * @param  {String} aeadAlgorithm             (optional) aead algorithm, e.g. 'eax' or 'ocb'
  * @param  {Key|Array<Key>} publicKeys        (optional) array of public keys or single key, used to encrypt the key
  * @param  {String|Array<String>} passwords   (optional) passwords for the message
  * @param  {Boolean} wildcard                 (optional) use a key ID of 0 instead of the public key IDs
@@ -402,16 +403,16 @@ export function verify({ message, publicKeys, signature=null, date=new Date() })
  * @async
  * @static
  */
-export function encryptSessionKey({ data, algorithm, publicKeys, passwords, wildcard=false }) {
+export function encryptSessionKey({ data, algorithm, aeadAlgorithm, publicKeys, passwords, wildcard=false }) {
   checkBinary(data); checkString(algorithm, 'algorithm'); publicKeys = toArray(publicKeys); passwords = toArray(passwords);
 
   if (asyncProxy) { // use web worker if available
-    return asyncProxy.delegate('encryptSessionKey', { data, algorithm, publicKeys, passwords, wildcard });
+    return asyncProxy.delegate('encryptSessionKey', { data, algorithm, aeadAlgorithm, publicKeys, passwords, wildcard });
   }
 
   return Promise.resolve().then(async function() {
 
-    return { message: await messageLib.encryptSessionKey(data, algorithm, publicKeys, passwords, wildcard) };
+    return { message: await messageLib.encryptSessionKey(data, algorithm, aeadAlgorithm, publicKeys, passwords, wildcard) };
 
   }).catch(onError.bind(null, 'Error encrypting session key'));
 }

--- a/src/openpgp.js
+++ b/src/openpgp.js
@@ -23,6 +23,7 @@
  * @requires cleartext
  * @requires key
  * @requires config
+ * @requires enums
  * @requires util
  * @requires polyfills
  * @requires worker/async_proxy
@@ -41,6 +42,7 @@ import * as messageLib from './message';
 import { CleartextMessage } from './cleartext';
 import { generate, reformat } from './key';
 import config from './config/config';
+import enums from './enums';
 import util from './util';
 import AsyncProxy from './worker/async_proxy';
 
@@ -581,10 +583,15 @@ function onError(message, error) {
 }
 
 /**
- * Check for AES-GCM support and configuration by the user. Only browsers that
- * implement the current WebCrypto specification support native AES-GCM.
+ * Check for native AEAD support and configuration by the user. Only
+ * browsers that implement the current WebCrypto specification support
+ * native GCM. Native EAX is built on CTR and CBC, which all browsers
+ * support. OCB and CFB are not natively supported.
  * @returns {Boolean}   If authenticated encryption should be used
  */
 function nativeAEAD() {
-  return util.getWebCrypto() && config.aead_protect;
+  return config.aead_protect && (
+    ((config.aead_protect_version !== 4 || config.aead_mode === enums.aead.gcm) && util.getWebCrypto()) ||
+    (config.aead_protect_version === 4 && config.aead_mode === enums.aead.eax && util.getWebCryptoAll())
+  );
 }

--- a/src/packet/literal.js
+++ b/src/packet/literal.js
@@ -37,7 +37,8 @@ function Literal(date=new Date()) {
   this.tag = enums.packet.literal;
   this.format = 'utf8'; // default format for literal data packets
   this.date = util.normalizeDate(date);
-  this.data = new Uint8Array(0); // literal data representation
+  this.text = null; // textual data representation
+  this.data = null; // literal data representation
   this.filename = 'msg.txt';
 }
 
@@ -45,13 +46,11 @@ function Literal(date=new Date()) {
  * Set the packet data to a javascript native string, end of line
  * will be normalized to \r\n and by default text is converted to UTF8
  * @param {String} text Any native javascript string
+ * @param {utf8|binary|text} format (optional) The format of the string of bytes
  */
-Literal.prototype.setText = function(text) {
-  // normalize EOL to \r\n
-  text = text.replace(/\r\n/g, "\n").replace(/\r/g, "\n").replace(/[ \t]+\n/g, "\n").replace(/\n/g, "\r\n");
-  this.format = 'utf8';
-  // encode UTF8
-  this.data = util.str_to_Uint8Array(util.encode_utf8(text));
+Literal.prototype.setText = function(text, format='utf8') {
+  this.format = format;
+  this.text = text;
 };
 
 /**
@@ -60,10 +59,14 @@ Literal.prototype.setText = function(text) {
  * @returns {String} literal data as text
  */
 Literal.prototype.getText = function() {
+  if (this.text !== null) {
+    return this.text;
+  }
   // decode UTF8
   const text = util.decode_utf8(util.Uint8Array_to_str(this.data));
   // normalize EOL to \n
-  return text.replace(/\r\n/g, '\n');
+  this.text = text.replace(/\r\n/g, '\n');
+  return this.text;
 };
 
 /**
@@ -82,6 +85,14 @@ Literal.prototype.setBytes = function(bytes, format) {
  * @returns {Uint8Array} A sequence of bytes
  */
 Literal.prototype.getBytes = function() {
+  if (this.data !== null) {
+    return this.data;
+  }
+
+  // normalize EOL to \r\n
+  const text = this.text.replace(/\r\n/g, '\n').replace(/\r/g, '\n').replace(/\n/g, '\r\n');
+  // encode UTF8
+  this.data = util.str_to_Uint8Array(util.encode_utf8(text));
   return this.data;
 };
 

--- a/src/packet/literal.js
+++ b/src/packet/literal.js
@@ -65,7 +65,7 @@ Literal.prototype.getText = function() {
   // decode UTF8
   const text = util.decode_utf8(util.Uint8Array_to_str(this.data));
   // normalize EOL to \n
-  this.text = text.replace(/\r\n/g, '\n');
+  this.text = util.nativeEOL(text);
   return this.text;
 };
 
@@ -90,7 +90,7 @@ Literal.prototype.getBytes = function() {
   }
 
   // normalize EOL to \r\n
-  const text = this.text.replace(/\r\n/g, '\n').replace(/\r/g, '\n').replace(/\n/g, '\r\n');
+  const text = util.canonicalizeEOL(this.text);
   // encode UTF8
   this.data = util.str_to_Uint8Array(util.encode_utf8(text));
   return this.data;

--- a/src/packet/literal.js
+++ b/src/packet/literal.js
@@ -46,7 +46,7 @@ function Literal(date=new Date()) {
  * Set the packet data to a javascript native string, end of line
  * will be normalized to \r\n and by default text is converted to UTF8
  * @param {String} text Any native javascript string
- * @param {utf8|binary|text} format (optional) The format of the string of bytes
+ * @param {utf8|binary|text|mime} format (optional) The format of the string of bytes
  */
 Literal.prototype.setText = function(text, format='utf8') {
   this.format = format;
@@ -72,7 +72,7 @@ Literal.prototype.getText = function() {
 /**
  * Set the packet data to value represented by the provided string of bytes.
  * @param {Uint8Array} bytes The string of bytes
- * @param {utf8|binary|text} format The format of the string of bytes
+ * @param {utf8|binary|text|mime} format The format of the string of bytes
  */
 Literal.prototype.setBytes = function(bytes, format) {
   this.format = format;

--- a/src/packet/packet.js
+++ b/src/packet/packet.js
@@ -177,15 +177,12 @@ export default {
       // 4.2.2.1. One-Octet Lengths
       if (input[mypos] < 192) {
         packet_length = input[mypos++];
-        util.print_debug("1 byte length:" + packet_length);
         // 4.2.2.2. Two-Octet Lengths
       } else if (input[mypos] >= 192 && input[mypos] < 224) {
         packet_length = ((input[mypos++] - 192) << 8) + (input[mypos++]) + 192;
-        util.print_debug("2 byte length:" + packet_length);
         // 4.2.2.4. Partial Body Lengths
       } else if (input[mypos] > 223 && input[mypos] < 255) {
         packet_length = 1 << (input[mypos++] & 0x1F);
-        util.print_debug("4 byte length:" + packet_length);
         // EEEK, we're reading the full data here...
         let mypos2 = mypos + packet_length;
         bodydata = [input.subarray(mypos, mypos + packet_length)];

--- a/src/packet/packetlist.js
+++ b/src/packet/packetlist.js
@@ -54,6 +54,7 @@ List.prototype.read = function (bytes) {
           parsed.tag === enums.packet.compressed) {
         throw e;
       }
+      util.print_debug_error(e);
       if (pushed) {
         this.pop(); // drop unsupported packet
       }

--- a/src/packet/public_key.js
+++ b/src/packet/public_key.js
@@ -54,7 +54,7 @@ function PublicKey(date=new Date()) {
    * Packet version
    * @type {Integer}
    */
-  this.version = config.aead_protect === 'draft04' ? 5 : 4;
+  this.version = config.aead_protect && config.aead_protect_version === 4 ? 5 : 4;
   /**
    * Key creation date.
    * @type {Date}

--- a/src/packet/public_key.js
+++ b/src/packet/public_key.js
@@ -202,9 +202,9 @@ PublicKey.prototype.getKeyId = function () {
 
 /**
  * Calculates the fingerprint of the key
- * @returns {String} A string containing the fingerprint in lowercase hex
+ * @returns {Uint8Array} A Uint8Array containing the fingerprint
  */
-PublicKey.prototype.getFingerprint = function () {
+PublicKey.prototype.getFingerprintBytes = function () {
   if (this.fingerprint) {
     return this.fingerprint;
   }
@@ -212,10 +212,10 @@ PublicKey.prototype.getFingerprint = function () {
   if (this.version === 5) {
     const bytes = this.writePublicKey();
     toHash = util.concatUint8Array([new Uint8Array([0x9A]), util.writeNumber(bytes.length, 4), bytes]);
-    this.fingerprint = util.Uint8Array_to_str(crypto.hash.sha256(toHash));
+    this.fingerprint = crypto.hash.sha256(toHash);
   } else if (this.version === 4) {
     toHash = this.writeOld();
-    this.fingerprint = util.Uint8Array_to_str(crypto.hash.sha1(toHash));
+    this.fingerprint = crypto.hash.sha1(toHash);
   } else if (this.version === 3) {
     const algo = enums.write(enums.publicKey, this.algorithm);
     const paramCount = crypto.getPubKeyParamTypes(algo).length;
@@ -223,10 +223,17 @@ PublicKey.prototype.getFingerprint = function () {
     for (let i = 0; i < paramCount; i++) {
       toHash += this.params[i].toString();
     }
-    this.fingerprint = util.Uint8Array_to_str(crypto.hash.md5(util.str_to_Uint8Array(toHash)));
+    this.fingerprint = crypto.hash.md5(util.str_to_Uint8Array(toHash));
   }
-  this.fingerprint = util.str_to_hex(this.fingerprint);
   return this.fingerprint;
+};
+
+/**
+ * Calculates the fingerprint of the key
+ * @returns {String} A string containing the fingerprint in lowercase hex
+ */
+PublicKey.prototype.getFingerprint = function () {
+  return util.Uint8Array_to_hex(this.getFingerprintBytes());
 };
 
 /**

--- a/src/packet/public_key_encrypted_session_key.js
+++ b/src/packet/public_key_encrypted_session_key.js
@@ -122,7 +122,7 @@ PublicKeyEncryptedSessionKey.prototype.encrypt = async function (key) {
   }
 
   this.encrypted = await crypto.publicKeyEncrypt(
-    algo, key.params, toEncrypt, key.fingerprint);
+    algo, key.params, toEncrypt, key.getFingerprintBytes());
   return true;
 };
 
@@ -138,7 +138,7 @@ PublicKeyEncryptedSessionKey.prototype.encrypt = async function (key) {
 PublicKeyEncryptedSessionKey.prototype.decrypt = async function (key) {
   const algo = enums.write(enums.publicKey, this.publicKeyAlgorithm);
   const result = await crypto.publicKeyDecrypt(
-    algo, key.params, this.encrypted, key.fingerprint);
+    algo, key.params, this.encrypted, key.getFingerprintBytes());
 
   let checksum;
   let decoded;

--- a/src/packet/secret_key.js
+++ b/src/packet/secret_key.js
@@ -211,7 +211,7 @@ SecretKey.prototype.encrypt = async function (passphrase) {
     arr = [new Uint8Array([253, optionalFields.length])];
     arr.push(optionalFields);
     const mode = crypto[aead];
-    const encrypted = await mode.encrypt(symmetric, cleartext, key, iv.subarray(0, mode.ivLength), new Uint8Array());
+    const encrypted = await new mode(symmetric, key).encrypt(cleartext, iv.subarray(0, mode.ivLength), new Uint8Array());
     arr.push(util.writeNumber(encrypted.length, 4));
     arr.push(encrypted);
   } else {
@@ -305,7 +305,7 @@ SecretKey.prototype.decrypt = async function (passphrase) {
   if (aead) {
     const mode = crypto[aead];
     try {
-      cleartext = await mode.decrypt(symmetric, ciphertext, key, iv.subarray(0, mode.ivLength), new Uint8Array());
+      cleartext = await new mode(symmetric, key).decrypt(ciphertext, iv.subarray(0, mode.ivLength), new Uint8Array());
     } catch(err) {
       if (err.message.startsWith('Authentication tag mismatch')) {
         throw new Error('Incorrect key passphrase: ' + err.message);

--- a/src/packet/secret_key.js
+++ b/src/packet/secret_key.js
@@ -211,7 +211,8 @@ SecretKey.prototype.encrypt = async function (passphrase) {
     arr = [new Uint8Array([253, optionalFields.length])];
     arr.push(optionalFields);
     const mode = crypto[aead];
-    const encrypted = await new mode(symmetric, key).encrypt(cleartext, iv.subarray(0, mode.ivLength), new Uint8Array());
+    const modeInstance = await mode(symmetric, key);
+    const encrypted = await modeInstance.encrypt(cleartext, iv.subarray(0, mode.ivLength), new Uint8Array());
     arr.push(util.writeNumber(encrypted.length, 4));
     arr.push(encrypted);
   } else {
@@ -305,7 +306,8 @@ SecretKey.prototype.decrypt = async function (passphrase) {
   if (aead) {
     const mode = crypto[aead];
     try {
-      cleartext = await new mode(symmetric, key).decrypt(ciphertext, iv.subarray(0, mode.ivLength), new Uint8Array());
+      const modeInstance = await mode(symmetric, key);
+      cleartext = await modeInstance.decrypt(ciphertext, iv.subarray(0, mode.ivLength), new Uint8Array());
     } catch(err) {
       if (err.message.startsWith('Authentication tag mismatch')) {
         throw new Error('Incorrect key passphrase: ' + err.message);

--- a/src/packet/signature.js
+++ b/src/packet/signature.js
@@ -551,9 +551,15 @@ Signature.prototype.toSign = function (type, data) {
 
   switch (type) {
     case t.binary:
-    case t.text:
       return data.getBytes();
 
+    case t.text: {
+      let text = data.getText();
+      // normalize EOL to \r\n
+      text = text.replace(/\r\n/g, '\n').replace(/\r/g, '\n').replace(/\n/g, '\r\n');
+      // encode UTF8
+      return util.str_to_Uint8Array(util.encode_utf8(text));
+    }
     case t.standalone:
       return new Uint8Array(0);
 

--- a/src/packet/signature.js
+++ b/src/packet/signature.js
@@ -84,6 +84,7 @@ function Signature(date=new Date()) {
   this.signatureTargetHashAlgorithm = null;
   this.signatureTargetHash = null;
   this.embeddedSignature = null;
+  this.preferredAeadAlgorithms = null;
 
   this.verified = null;
   this.revoked = null;
@@ -355,6 +356,10 @@ Signature.prototype.write_all_sub_packets = function () {
   if (this.embeddedSignature !== null) {
     arr.push(write_sub_packet(sub.embedded_signature, this.embeddedSignature.write()));
   }
+  if (this.preferredAeadAlgorithms !== null) {
+    bytes = util.str_to_Uint8Array(util.Uint8Array_to_str(this.preferredAeadAlgorithms));
+    arr.push(write_sub_packet(sub.preferred_aead_algorithms, bytes));
+  }
 
   const result = util.concatUint8Array(arr);
   const length = util.writeNumber(result.length, 2);
@@ -530,6 +535,10 @@ Signature.prototype.read_sub_packet = function (bytes) {
       // Embedded Signature
       this.embeddedSignature = new Signature();
       this.embeddedSignature.read(bytes.subarray(mypos, bytes.length));
+      break;
+    case 34:
+      // Preferred AEAD Algorithms
+      read_array.call(this, 'preferredAeadAlgorithms', bytes.subarray(mypos, bytes.length));
       break;
     default:
       util.print_debug("Unknown signature subpacket type " + type + " @:" + mypos);

--- a/src/packet/signature.js
+++ b/src/packet/signature.js
@@ -556,7 +556,7 @@ Signature.prototype.toSign = function (type, data) {
     case t.text: {
       let text = data.getText();
       // normalize EOL to \r\n
-      text = text.replace(/\r\n/g, '\n').replace(/\r/g, '\n').replace(/\n/g, '\r\n');
+      text = util.canonicalizeEOL(text);
       // encode UTF8
       return util.str_to_Uint8Array(util.encode_utf8(text));
     }

--- a/src/packet/signature.js
+++ b/src/packet/signature.js
@@ -84,6 +84,8 @@ function Signature(date=new Date()) {
   this.signatureTargetHashAlgorithm = null;
   this.signatureTargetHash = null;
   this.embeddedSignature = null;
+  this.issuerKeyVersion = null;
+  this.issuerFingerprint = null;
   this.preferredAeadAlgorithms = null;
 
   this.verified = null;
@@ -223,6 +225,13 @@ Signature.prototype.sign = async function (key, data) {
 
   const arr = [new Uint8Array([4, signatureType, publicKeyAlgorithm, hashAlgorithm])];
 
+  if (key.version === 5) {
+    // We could also generate this subpacket for version 4 keys, but for
+    // now we don't.
+    this.issuerKeyVersion = key.version;
+    this.issuerFingerprint = key.getFingerprintBytes();
+  }
+
   this.issuerKeyId = key.getKeyId();
 
   // Add hashed subpackets
@@ -293,7 +302,9 @@ Signature.prototype.write_all_sub_packets = function () {
     bytes = util.concatUint8Array([bytes, this.revocationKeyFingerprint]);
     arr.push(write_sub_packet(sub.revocation_key, bytes));
   }
-  if (!this.issuerKeyId.isNull()) {
+  if (!this.issuerKeyId.isNull() && this.issuerKeyVersion !== 5) {
+    // If the version of [the] key is greater than 4, this subpacket
+    // MUST NOT be included in the signature.
     arr.push(write_sub_packet(sub.issuer, this.issuerKeyId.write()));
   }
   if (this.notation !== null) {
@@ -355,6 +366,11 @@ Signature.prototype.write_all_sub_packets = function () {
   }
   if (this.embeddedSignature !== null) {
     arr.push(write_sub_packet(sub.embedded_signature, this.embeddedSignature.write()));
+  }
+  if (this.issuerFingerprint !== null) {
+    bytes = [new Uint8Array([this.issuerKeyVersion]), this.issuerFingerprint];
+    bytes = util.concatUint8Array(bytes);
+    arr.push(write_sub_packet(sub.issuer_fingerprint, bytes));
   }
   if (this.preferredAeadAlgorithms !== null) {
     bytes = util.str_to_Uint8Array(util.Uint8Array_to_str(this.preferredAeadAlgorithms));
@@ -535,6 +551,16 @@ Signature.prototype.read_sub_packet = function (bytes) {
       // Embedded Signature
       this.embeddedSignature = new Signature();
       this.embeddedSignature.read(bytes.subarray(mypos, bytes.length));
+      break;
+    case 33:
+      // Issuer Fingerprint
+      this.issuerKeyVersion = bytes[mypos++];
+      this.issuerFingerprint = bytes.subarray(mypos, bytes.length);
+      if (this.issuerKeyVersion === 5) {
+        this.issuerKeyId.read(this.issuerFingerprint);
+      } else {
+        this.issuerKeyId.read(this.issuerFingerprint.subarray(-8));
+      }
       break;
     case 34:
       // Preferred AEAD Algorithms

--- a/src/packet/sym_encrypted_aead_protected.js
+++ b/src/packet/sym_encrypted_aead_protected.js
@@ -107,7 +107,7 @@ SymEncryptedAEADProtected.prototype.decrypt = async function (sessionKeyAlgorith
     adataArray.set([0xC0 | this.tag, this.version, this.cipherAlgo, this.aeadAlgo, this.chunkSizeByte], 0);
     adataView.setInt32(13 + 4, data.length - mode.blockLength); // Should be setInt64(13, ...)
     const decryptedPromises = [];
-    const modeInstance = new mode(cipher, key);
+    const modeInstance = await mode(cipher, key);
     for (let chunkIndex = 0; chunkIndex === 0 || data.length;) {
       decryptedPromises.push(
         modeInstance.decrypt(data.subarray(0, chunkSize), mode.getNonce(this.iv, chunkIndexArray), adataArray)
@@ -149,7 +149,7 @@ SymEncryptedAEADProtected.prototype.encrypt = async function (sessionKeyAlgorith
     adataArray.set([0xC0 | this.tag, this.version, this.cipherAlgo, this.aeadAlgo, this.chunkSizeByte], 0);
     adataView.setInt32(13 + 4, data.length); // Should be setInt64(13, ...)
     const encryptedPromises = [];
-    const modeInstance = new mode(sessionKeyAlgorithm, key);
+    const modeInstance = await mode(sessionKeyAlgorithm, key);
     for (let chunkIndex = 0; chunkIndex === 0 || data.length;) {
       encryptedPromises.push(
         modeInstance.encrypt(data.subarray(0, chunkSize), mode.getNonce(this.iv, chunkIndexArray), adataArray)

--- a/src/packet/sym_encrypted_aead_protected.js
+++ b/src/packet/sym_encrypted_aead_protected.js
@@ -42,6 +42,7 @@ function SymEncryptedAEADProtected() {
   this.tag = enums.packet.symEncryptedAEADProtected;
   this.version = VERSION;
   this.cipherAlgo = null;
+  this.aeadAlgorithm = 'eax';
   this.aeadAlgo = null;
   this.chunkSizeByte = null;
   this.iv = null;
@@ -131,7 +132,7 @@ SymEncryptedAEADProtected.prototype.decrypt = async function (sessionKeyAlgorith
  * @async
  */
 SymEncryptedAEADProtected.prototype.encrypt = async function (sessionKeyAlgorithm, key) {
-  this.aeadAlgo = config.aead_protect === 'draft04' ? enums.aead.eax : enums.aead.gcm;
+  this.aeadAlgo = config.aead_protect === 'draft04' ? enums.write(enums.aead, this.aeadAlgorithm) : enums.aead.gcm;
   const mode = crypto[enums.read(enums.aead, this.aeadAlgo)];
   this.iv = await crypto.random.getRandomBytes(mode.ivLength); // generate new random IV
   let data = this.packets.write();

--- a/src/packet/sym_encrypted_aead_protected.js
+++ b/src/packet/sym_encrypted_aead_protected.js
@@ -165,4 +165,4 @@ SymEncryptedAEADProtected.prototype.crypt = async function (fn, key, data, final
   } else {
     return modeInstance[fn](data, this.iv);
   }
-}
+};

--- a/src/packet/sym_encrypted_session_key.js
+++ b/src/packet/sym_encrypted_session_key.js
@@ -49,7 +49,7 @@ import util from '../util';
  */
 function SymEncryptedSessionKey() {
   this.tag = enums.packet.symEncryptedSessionKey;
-  this.version = config.aead_protect === 'draft04' ? 5 : 4;
+  this.version = config.aead_protect && config.aead_protect_version === 4 ? 5 : 4;
   this.sessionKey = null;
   this.sessionKeyEncryptionAlgorithm = null;
   this.sessionKeyAlgorithm = 'aes256';

--- a/src/packet/sym_encrypted_session_key.js
+++ b/src/packet/sym_encrypted_session_key.js
@@ -53,7 +53,7 @@ function SymEncryptedSessionKey() {
   this.sessionKey = null;
   this.sessionKeyEncryptionAlgorithm = null;
   this.sessionKeyAlgorithm = 'aes256';
-  this.aeadAlgorithm = 'eax';
+  this.aeadAlgorithm = enums.read(enums.aead, config.aead_mode);
   this.encrypted = null;
   this.s2k = null;
   this.iv = null;

--- a/src/packet/sym_encrypted_session_key.js
+++ b/src/packet/sym_encrypted_session_key.js
@@ -142,7 +142,8 @@ SymEncryptedSessionKey.prototype.decrypt = async function(passphrase) {
   if (this.version === 5) {
     const mode = crypto[this.aeadAlgorithm];
     const adata = new Uint8Array([0xC0 | this.tag, this.version, enums.write(enums.symmetric, this.sessionKeyEncryptionAlgorithm), enums.write(enums.aead, this.aeadAlgorithm)]);
-    this.sessionKey = await new mode(algo, key).decrypt(this.encrypted, this.iv, adata);
+    const modeInstance = await mode(algo, key);
+    this.sessionKey = await modeInstance.decrypt(this.encrypted, this.iv, adata);
   } else if (this.encrypted !== null) {
     const decrypted = crypto.cfb.normalDecrypt(algo, key, this.encrypted, null);
 
@@ -182,7 +183,8 @@ SymEncryptedSessionKey.prototype.encrypt = async function(passphrase) {
     const mode = crypto[this.aeadAlgorithm];
     this.iv = await crypto.random.getRandomBytes(mode.ivLength); // generate new random IV
     const adata = new Uint8Array([0xC0 | this.tag, this.version, enums.write(enums.symmetric, this.sessionKeyEncryptionAlgorithm), enums.write(enums.aead, this.aeadAlgorithm)]);
-    this.encrypted = await new mode(algo, key).encrypt(this.sessionKey, this.iv, adata);
+    const modeInstance = await mode(algo, key);
+    this.encrypted = await modeInstance.encrypt(this.sessionKey, this.iv, adata);
   } else {
     const algo_enum = new Uint8Array([enums.write(enums.symmetric, this.sessionKeyAlgorithm)]);
 

--- a/src/packet/sym_encrypted_session_key.js
+++ b/src/packet/sym_encrypted_session_key.js
@@ -17,12 +17,14 @@
 
 /**
  * @requires type/s2k
+ * @requires config
  * @requires crypto
  * @requires enums
  * @requires util
  */
 
 import type_s2k from '../type/s2k';
+import config from '../config';
 import crypto from '../crypto';
 import enums from '../enums';
 import util from '../util';
@@ -47,12 +49,14 @@ import util from '../util';
  */
 function SymEncryptedSessionKey() {
   this.tag = enums.packet.symEncryptedSessionKey;
-  this.version = 4;
+  this.version = config.aead_protect === 'draft04' ? 5 : 4;
   this.sessionKey = null;
   this.sessionKeyEncryptionAlgorithm = null;
   this.sessionKeyAlgorithm = 'aes256';
+  this.aeadAlgorithm = 'eax';
   this.encrypted = null;
   this.s2k = null;
+  this.iv = null;
 }
 
 /**
@@ -66,22 +70,35 @@ function SymEncryptedSessionKey() {
  * @returns {module:packet.SymEncryptedSessionKey} Object representation
  */
 SymEncryptedSessionKey.prototype.read = function(bytes) {
+  let offset = 0;
+
   // A one-octet version number. The only currently defined version is 4.
-  [this.version] = bytes;
+  this.version = bytes[offset++];
 
   // A one-octet number describing the symmetric algorithm used.
-  const algo = enums.read(enums.symmetric, bytes[1]);
+  const algo = enums.read(enums.symmetric, bytes[offset++]);
+
+  if (this.version === 5) {
+    // A one-octet AEAD algorithm.
+    this.aeadAlgorithm = enums.read(enums.aead, bytes[offset++]);
+  }
 
   // A string-to-key (S2K) specifier, length as defined above.
   this.s2k = new type_s2k();
-  const s2klength = this.s2k.read(bytes.subarray(2, bytes.length));
+  offset += this.s2k.read(bytes.subarray(offset, bytes.length));
 
-  // Optionally, the encrypted session key itself, which is decrypted
-  // with the string-to-key object.
-  const done = s2klength + 2;
+  if (this.version === 5) {
+    const mode = crypto[this.aeadAlgorithm];
 
-  if (done < bytes.length) {
-    this.encrypted = bytes.subarray(done, bytes.length);
+    // A starting initialization vector of size specified by the AEAD
+    // algorithm.
+    this.iv = bytes.subarray(offset, offset += mode.ivLength);
+  }
+
+  // The encrypted session key itself, which is decrypted with the
+  // string-to-key object. This is optional in version 4.
+  if (this.version === 5 || offset < bytes.length) {
+    this.encrypted = bytes.subarray(offset, bytes.length);
     this.sessionKeyEncryptionAlgorithm = algo;
   } else {
     this.sessionKeyAlgorithm = algo;
@@ -93,11 +110,18 @@ SymEncryptedSessionKey.prototype.write = function() {
     this.sessionKeyAlgorithm :
     this.sessionKeyEncryptionAlgorithm;
 
-  let bytes = util.concatUint8Array([new Uint8Array([this.version, enums.write(enums.symmetric, algo)]), this.s2k.write()]);
+  let bytes;
 
-  if (this.encrypted !== null) {
-    bytes = util.concatUint8Array([bytes, this.encrypted]);
+  if (this.version === 5) {
+    bytes = util.concatUint8Array([new Uint8Array([this.version, enums.write(enums.symmetric, algo), enums.write(enums.aead, this.aeadAlgorithm)]), this.s2k.write(), this.iv, this.encrypted]);
+  } else {
+    bytes = util.concatUint8Array([new Uint8Array([this.version, enums.write(enums.symmetric, algo)]), this.s2k.write()]);
+
+    if (this.encrypted !== null) {
+      bytes = util.concatUint8Array([bytes, this.encrypted]);
+    }
   }
+
   return bytes;
 };
 
@@ -115,14 +139,19 @@ SymEncryptedSessionKey.prototype.decrypt = async function(passphrase) {
   const length = crypto.cipher[algo].keySize;
   const key = this.s2k.produce_key(passphrase, length);
 
-  if (this.encrypted === null) {
-    this.sessionKey = key;
-  } else {
+  if (this.version === 5) {
+    const mode = crypto[this.aeadAlgorithm];
+    const adata = new Uint8Array([0xC0 | this.tag, this.version, enums.write(enums.symmetric, this.sessionKeyEncryptionAlgorithm), enums.write(enums.aead, this.aeadAlgorithm)]);
+    this.sessionKey = await mode.decrypt(algo, this.encrypted, key, this.iv, adata);
+  } else if (this.encrypted !== null) {
     const decrypted = crypto.cfb.normalDecrypt(algo, key, this.encrypted, null);
 
     this.sessionKeyAlgorithm = enums.read(enums.symmetric, decrypted[0]);
     this.sessionKey = decrypted.subarray(1, decrypted.length);
+  } else {
+    this.sessionKey = key;
   }
+
   return true;
 };
 
@@ -145,14 +174,23 @@ SymEncryptedSessionKey.prototype.encrypt = async function(passphrase) {
   const length = crypto.cipher[algo].keySize;
   const key = this.s2k.produce_key(passphrase, length);
 
-  const algo_enum = new Uint8Array([enums.write(enums.symmetric, this.sessionKeyAlgorithm)]);
-
   if (this.sessionKey === null) {
     this.sessionKey = await crypto.generateSessionKey(this.sessionKeyAlgorithm);
   }
-  const private_key = util.concatUint8Array([algo_enum, this.sessionKey]);
 
-  this.encrypted = crypto.cfb.normalEncrypt(algo, key, private_key, null);
+  if (this.version === 5) {
+    const mode = crypto[this.aeadAlgorithm];
+    this.iv = await crypto.random.getRandomBytes(mode.ivLength); // generate new random IV
+    const adata = new Uint8Array([0xC0 | this.tag, this.version, enums.write(enums.symmetric, this.sessionKeyEncryptionAlgorithm), enums.write(enums.aead, this.aeadAlgorithm)]);
+    this.encrypted = await mode.encrypt(algo, this.sessionKey, key, this.iv, adata);
+  } else {
+    const algo_enum = new Uint8Array([enums.write(enums.symmetric, this.sessionKeyAlgorithm)]);
+
+    const private_key = util.concatUint8Array([algo_enum, this.sessionKey]);
+
+    this.encrypted = crypto.cfb.normalEncrypt(algo, key, private_key, null);
+  }
+
   return true;
 };
 

--- a/src/packet/sym_encrypted_session_key.js
+++ b/src/packet/sym_encrypted_session_key.js
@@ -142,7 +142,7 @@ SymEncryptedSessionKey.prototype.decrypt = async function(passphrase) {
   if (this.version === 5) {
     const mode = crypto[this.aeadAlgorithm];
     const adata = new Uint8Array([0xC0 | this.tag, this.version, enums.write(enums.symmetric, this.sessionKeyEncryptionAlgorithm), enums.write(enums.aead, this.aeadAlgorithm)]);
-    this.sessionKey = await mode.decrypt(algo, this.encrypted, key, this.iv, adata);
+    this.sessionKey = await new mode(algo, key).decrypt(this.encrypted, this.iv, adata);
   } else if (this.encrypted !== null) {
     const decrypted = crypto.cfb.normalDecrypt(algo, key, this.encrypted, null);
 
@@ -182,7 +182,7 @@ SymEncryptedSessionKey.prototype.encrypt = async function(passphrase) {
     const mode = crypto[this.aeadAlgorithm];
     this.iv = await crypto.random.getRandomBytes(mode.ivLength); // generate new random IV
     const adata = new Uint8Array([0xC0 | this.tag, this.version, enums.write(enums.symmetric, this.sessionKeyEncryptionAlgorithm), enums.write(enums.aead, this.aeadAlgorithm)]);
-    this.encrypted = await mode.encrypt(algo, this.sessionKey, key, this.iv, adata);
+    this.encrypted = await new mode(algo, key).encrypt(this.sessionKey, this.iv, adata);
   } else {
     const algo_enum = new Uint8Array([enums.write(enums.symmetric, this.sessionKeyAlgorithm)]);
 

--- a/src/type/s2k.js
+++ b/src/type/s2k.js
@@ -24,15 +24,17 @@
  * places, currently: to encrypt the secret part of private keys in the
  * private keyring, and to convert passphrases to encryption keys for
  * symmetrically encrypted messages.
+ * @requires config
  * @requires crypto
  * @requires enums
  * @requires util
  * @module type/s2k
  */
 
+import config from '../config';
+import crypto from '../crypto';
 import enums from '../enums.js';
 import util from '../util.js';
-import crypto from '../crypto';
 
 /**
  * @constructor
@@ -42,7 +44,8 @@ function S2K() {
   this.algorithm = 'sha256';
   /** @type {module:enums.s2k} */
   this.type = 'iterated';
-  this.c = 96;
+  /** @type {Integer} */
+  this.c = config.s2k_iteration_count_byte;
   /** Eight bytes of salt in a binary string.
    * @type {String}
    */

--- a/src/util.js
+++ b/src/util.js
@@ -574,5 +574,26 @@ export default {
       return false;
     }
     return /</.test(data) && />$/.test(data);
+  },
+
+  /**
+   * Normalize line endings to \r\n
+   */
+  canonicalizeEOL: function(text) {
+    return text.replace(/\r\n/g, "\n").replace(/\r/g, "\n").replace(/\n/g, "\r\n");
+  },
+
+  /**
+   * Convert line endings from canonicalized \r\n to native \n
+   */
+  nativeEOL: function(text) {
+    return text.replace(/\r\n/g, "\n");
+  },
+
+  /**
+   * Remove trailing spaces and tabs from each line
+   */
+  removeTrailingSpaces: function(text) {
+    return text.replace(/[ \t]+$/mg, "");
   }
 };

--- a/src/util.js
+++ b/src/util.js
@@ -444,22 +444,22 @@ export default {
   },
 
   /**
-   * Shift a Uint8Array to the left by n bits
-   * @param {Uint8Array} array The array to shift
-   * @param {Integer} bits Amount of bits to shift (MUST be smaller
-   * than 8)
-   * @returns {String} Resulting array.
+   * If S[1] == 0, then double(S) == (S[2..128] || 0);
+   * otherwise, double(S) == (S[2..128] || 0) xor
+   * (zeros(120) || 10000111).
+   *
+   * Both OCB and EAX (through CMAC) require this function to be constant-time.
+   *
+   * @param {Uint8Array} data
    */
-  shiftLeft: function (array, bits) {
-    if (bits) {
-      for (let i = 0; i < array.length; i++) {
-        array[i] <<= bits;
-        if (i + 1 < array.length) {
-          array[i] |= array[i + 1] >> (8 - bits);
-        }
-      }
+  double: function(data) {
+    const double = new Uint8Array(data.length);
+    const last = data.length - 1;
+    for (let i = 0; i < last; i++) {
+      double[i] = (data[i] << 1) ^ (data[i + 1] >> 7);
     }
-    return array;
+    double[last] = (data[last] << 1) ^ ((data[0] >> 7) * 0x87);
+    return double;
   },
 
   /**

--- a/src/util.js
+++ b/src/util.js
@@ -366,6 +366,20 @@ export default {
    * Helper function to print a debug message. Debug
    * messages are only printed if
    * @link module:config/config.debug is set to true.
+   * Different than print_debug because will call Uint8Array_to_hex iff necessary.
+   * @param {String} str String of the debug message
+   */
+  print_debug_hexarray_dump: function (str, arrToHex) {
+    if (config.debug) {
+      str += ': ' + util.Uint8Array_to_hex(arrToHex);
+      console.log(str);
+    }
+  },
+
+  /**
+   * Helper function to print a debug message. Debug
+   * messages are only printed if
+   * @link module:config/config.debug is set to true.
    * Different than print_debug because will call str_to_hex iff necessary.
    * @param {String} str String of the debug message
    */

--- a/src/util.js
+++ b/src/util.js
@@ -388,14 +388,13 @@ export default {
     }
   },
 
-  // TODO rewrite getLeftNBits to work with Uint8Arrays
-  getLeftNBits: function (string, bitcount) {
+  getLeftNBits: function (array, bitcount) {
     const rest = bitcount % 8;
     if (rest === 0) {
-      return string.substring(0, bitcount / 8);
+      return array.subarray(0, bitcount / 8);
     }
     const bytes = (bitcount - rest) / 8 + 1;
-    const result = string.substring(0, bytes);
+    const result = array.subarray(0, bytes);
     return util.shiftRight(result, 8 - rest); // +String.fromCharCode(string.charCodeAt(bytes -1) << (8-rest) & 0xFF);
   },
 
@@ -431,25 +430,41 @@ export default {
   },
 
   /**
-   * Shifting a string to n bits right
-   * @param {String} value The string to shift
-   * @param {Integer} bitcount Amount of bits to shift (MUST be smaller
-   * than 9)
-   * @returns {String} Resulting string.
+   * Shift a Uint8Array to the left by n bits
+   * @param {Uint8Array} array The array to shift
+   * @param {Integer} bits Amount of bits to shift (MUST be smaller
+   * than 8)
+   * @returns {String} Resulting array.
    */
-  shiftRight: function (value, bitcount) {
-    const temp = util.str_to_Uint8Array(value);
-    if (bitcount % 8 !== 0) {
-      for (let i = temp.length - 1; i >= 0; i--) {
-        temp[i] >>= bitcount % 8;
-        if (i > 0) {
-          temp[i] |= (temp[i - 1] << (8 - (bitcount % 8))) & 0xFF;
+  shiftLeft: function (array, bits) {
+    if (bits) {
+      for (let i = 0; i < array.length; i++) {
+        array[i] <<= bits;
+        if (i + 1 < array.length) {
+          array[i] |= array[i + 1] >> (8 - bits);
         }
       }
-    } else {
-      return value;
     }
-    return util.Uint8Array_to_str(temp);
+    return array;
+  },
+
+  /**
+   * Shift a Uint8Array to the right by n bits
+   * @param {Uint8Array} array The array to shift
+   * @param {Integer} bits Amount of bits to shift (MUST be smaller
+   * than 8)
+   * @returns {String} Resulting array.
+   */
+  shiftRight: function (array, bits) {
+    if (bits) {
+      for (let i = array.length - 1; i >= 0; i--) {
+        array[i] >>= bits;
+        if (i > 0) {
+          array[i] |= (array[i - 1] << (8 - bits));
+        }
+      }
+    }
+    return array;
   },
 
   /**

--- a/src/util.js
+++ b/src/util.js
@@ -376,6 +376,18 @@ export default {
     }
   },
 
+  /**
+   * Helper function to print a debug error. Debug
+   * messages are only printed if
+   * @link module:config/config.debug is set to true.
+   * @param {String} str String of the debug message
+   */
+  print_debug_error: function (error) {
+    if (config.debug) {
+      console.error(error);
+    }
+  },
+
   // TODO rewrite getLeftNBits to work with Uint8Arrays
   getLeftNBits: function (string, bitcount) {
     const rest = bitcount % 8;

--- a/test/crypto/cipher/aes.js
+++ b/test/crypto/cipher/aes.js
@@ -7,11 +7,13 @@ const { expect } = chai;
 
 describe('AES Rijndael cipher test with test vectors from ecb_tbl.txt', function() {
   function test_aes(input, key, output) {
-    const aes = new openpgp.crypto.cipher.aes128(key);
+    const aes = new openpgp.crypto.cipher.aes128(new Uint8Array(key));
 
-    const result = util.Uint8Array_to_str(aes.encrypt(new Uint8Array(input)));
+    const encrypted = aes.encrypt(new Uint8Array(input));
+    expect(encrypted).to.deep.equal(new Uint8Array(output));
 
-    return util.str_to_hex(result) === util.str_to_hex(util.Uint8Array_to_str(output));
+    const decrypted = aes.decrypt(new Uint8Array(output));
+    expect(decrypted).to.deep.equal(new Uint8Array(input));
   }
 
   const testvectors128 = [[[0x00,0x01,0x02,0x03,0x05,0x06,0x07,0x08,0x0A,0x0B,0x0C,0x0D,0x0F,0x10,0x11,0x12],[0x50,0x68,0x12,0xA4,0x5F,0x08,0xC8,0x89,0xB9,0x7F,0x59,0x80,0x03,0x8B,0x83,0x59],[0xD8,0xF5,0x32,0x53,0x82,0x89,0xEF,0x7D,0x06,0xB5,0x06,0xA4,0xFD,0x5B,0xE9,0xC9]],
@@ -64,30 +66,21 @@ describe('AES Rijndael cipher test with test vectors from ecb_tbl.txt', function
 
   it('128 bit key', function (done) {
     for (let i = 0; i < testvectors128.length; i++) {
-      const res = test_aes(testvectors128[i][1],testvectors128[i][0],testvectors128[i][2]);
-      expect(res, 'block ' + util.Uint8Array_to_hex(testvectors128[i][1]) +
-                  ' and key '+util.Uint8Array_to_hex(testvectors128[i][0]) +
-                  ' should be '+util.Uint8Array_to_hex(testvectors128[i][2])).to.be.true;
+      test_aes(testvectors128[i][1],testvectors128[i][0],testvectors128[i][2]);
     }
     done();
   });
 
   it('192 bit key', function (done) {
     for (let i = 0; i < testvectors192.length; i++) {
-      const res = test_aes(testvectors192[i][1],testvectors192[i][0],testvectors192[i][2]);
-      expect(res, 'block ' + util.Uint8Array_to_hex(testvectors192[i][1]) +
-                  ' and key ' + util.Uint8Array_to_hex(testvectors192[i][0])+
-                  ' should be ' + util.Uint8Array_to_hex(testvectors192[i][2])).to.be.true;
+      test_aes(testvectors192[i][1],testvectors192[i][0],testvectors192[i][2]);
     }
     done();
   });
 
   it('256 bit key', function (done) {
     for (let i = 0; i < testvectors256.length; i++) {
-      const res = test_aes(testvectors256[i][1],testvectors256[i][0],testvectors256[i][2]);
-      expect(res, 'block ' + util.Uint8Array_to_hex(testvectors256[i][1]) +
-                  ' and key ' + util.Uint8Array_to_hex(testvectors256[i][0]) +
-                  ' should be ' + util.Uint8Array_to_hex(testvectors256[i][2])).to.be.true;
+      test_aes(testvectors256[i][1],testvectors256[i][0],testvectors256[i][2]);
     }
     done();
   });

--- a/test/crypto/eax.js
+++ b/test/crypto/eax.js
@@ -94,7 +94,7 @@ function testAESEAX() {
         headerBytes = openpgp.util.hex_to_Uint8Array(vec.header),
         ctBytes = openpgp.util.hex_to_Uint8Array(vec.ct);
 
-      const eax = new openpgp.crypto.eax(cipher, keyBytes);
+      const eax = await openpgp.crypto.eax(cipher, keyBytes);
 
       // encryption test
       let ct = await eax.encrypt(msgBytes, nonceBytes, headerBytes);

--- a/test/crypto/eax.js
+++ b/test/crypto/eax.js
@@ -1,0 +1,150 @@
+// Modified by ProtonTech AG
+
+// Adapted from https://github.com/artjomb/cryptojs-extension/blob/8c61d159/test/eax.js
+
+const openpgp = typeof window !== 'undefined' && window.openpgp ? window.openpgp : require('../../dist/openpgp');
+
+const chai = require('chai');
+chai.use(require('chai-as-promised'));
+
+const expect = chai.expect;
+
+const eax = openpgp.crypto.eax;
+
+function testAESEAX() {
+  it('Passes all test vectors', async function() {
+    var vectors = [
+      // From http://www.cs.ucdavis.edu/~rogaway/papers/eax.pdf ...
+      {
+        msg: "",
+        key: "233952DEE4D5ED5F9B9C6D6FF80FF478",
+        nonce: "62EC67F9C3A4A407FCB2A8C49031A8B3",
+        header: "6BFB914FD07EAE6B",
+        ct: "E037830E8389F27B025A2D6527E79D01"
+      },
+      {
+        msg: "F7FB",
+        key: "91945D3F4DCBEE0BF45EF52255F095A4",
+        nonce: "BECAF043B0A23D843194BA972C66DEBD",
+        header: "FA3BFD4806EB53FA",
+        ct: "19DD5C4C9331049D0BDAB0277408F67967E5"
+      },
+      {
+        msg: "1A47CB4933",
+        key: "01F74AD64077F2E704C0F60ADA3DD523",
+        nonce: "70C3DB4F0D26368400A10ED05D2BFF5E",
+        header: "234A3463C1264AC6",
+        ct: "D851D5BAE03A59F238A23E39199DC9266626C40F80"
+      },
+      {
+        msg: "481C9E39B1",
+        key: "D07CF6CBB7F313BDDE66B727AFD3C5E8",
+        nonce: "8408DFFF3C1A2B1292DC199E46B7D617",
+        header: "33CCE2EABFF5A79D",
+        ct: "632A9D131AD4C168A4225D8E1FF755939974A7BEDE"
+      },
+      {
+        msg: "40D0C07DA5E4",
+        key: "35B6D0580005BBC12B0587124557D2C2",
+        nonce: "FDB6B06676EEDC5C61D74276E1F8E816",
+        header: "AEB96EAEBE2970E9",
+        ct: "071DFE16C675CB0677E536F73AFE6A14B74EE49844DD"
+      },
+      {
+        msg: "4DE3B35C3FC039245BD1FB7D",
+        key: "BD8E6E11475E60B268784C38C62FEB22",
+        nonce: "6EAC5C93072D8E8513F750935E46DA1B",
+        header: "D4482D1CA78DCE0F",
+        ct: "835BB4F15D743E350E728414ABB8644FD6CCB86947C5E10590210A4F"
+      },
+      {
+        msg: "8B0A79306C9CE7ED99DAE4F87F8DD61636",
+        key: "7C77D6E813BED5AC98BAA417477A2E7D",
+        nonce: "1A8C98DCD73D38393B2BF1569DEEFC19",
+        header: "65D2017990D62528",
+        ct: "02083E3979DA014812F59F11D52630DA30137327D10649B0AA6E1C181DB617D7F2"
+      },
+      {
+        msg: "1BDA122BCE8A8DBAF1877D962B8592DD2D56",
+        key: "5FFF20CAFAB119CA2FC73549E20F5B0D",
+        nonce: "DDE59B97D722156D4D9AFF2BC7559826",
+        header: "54B9F04E6A09189A",
+        ct: "2EC47B2C4954A489AFC7BA4897EDCDAE8CC33B60450599BD02C96382902AEF7F832A"
+      },
+      {
+        msg: "6CF36720872B8513F6EAB1A8A44438D5EF11",
+        key: "A4A4782BCFFD3EC5E7EF6D8C34A56123",
+        nonce: "B781FCF2F75FA5A8DE97A9CA48E522EC",
+        header: "899A175897561D7E",
+        ct: "0DE18FD0FDD91E7AF19F1D8EE8733938B1E8E7F6D2231618102FDB7FE55FF1991700"
+      },
+      {
+        msg: "CA40D7446E545FFAED3BD12A740A659FFBBB3CEAB7",
+        key: "8395FCF1E95BEBD697BD010BC766AAC3",
+        nonce: "22E7ADD93CFC6393C57EC0B3C17D6B44",
+        header: "126735FCC320D25A",
+        ct: "CB8920F87A6C75CFF39627B56E3ED197C552D295A7CFC46AFC253B4652B1AF3795B124AB6E"
+      },
+    ];
+
+    const cipher = 'aes128';
+
+    for(const [i, vec] of vectors.entries()) {
+      const keyBytes = openpgp.util.hex_to_Uint8Array(vec.key),
+        msgBytes = openpgp.util.hex_to_Uint8Array(vec.msg),
+        nonceBytes = openpgp.util.hex_to_Uint8Array(vec.nonce),
+        headerBytes = openpgp.util.hex_to_Uint8Array(vec.header),
+        ctBytes = openpgp.util.hex_to_Uint8Array(vec.ct);
+
+      // encryption test
+      let ct = await eax.encrypt(cipher, msgBytes, keyBytes, nonceBytes, headerBytes);
+      expect(openpgp.util.Uint8Array_to_hex(ct)).to.equal(vec.ct.toLowerCase());
+
+      // decryption test with verification
+      let pt = await eax.decrypt(cipher, ctBytes, keyBytes, nonceBytes, headerBytes);
+      expect(openpgp.util.Uint8Array_to_hex(pt)).to.equal(vec.msg.toLowerCase());
+
+      // tampering detection test
+      ct = await eax.encrypt(cipher, msgBytes, keyBytes, nonceBytes, headerBytes);
+      ct[2] ^= 8;
+      pt = eax.decrypt(cipher, ct, keyBytes, nonceBytes, headerBytes);
+      await expect(pt).to.eventually.be.rejectedWith('Authentication tag mismatch in EAX ciphertext')
+
+      // testing without additional data
+      ct = await eax.encrypt(cipher, msgBytes, keyBytes, nonceBytes, new Uint8Array());
+      pt = await eax.decrypt(cipher, ct, keyBytes, nonceBytes, new Uint8Array());
+      expect(openpgp.util.Uint8Array_to_hex(pt)).to.equal(vec.msg.toLowerCase());
+
+      // testing with multiple additional data
+      ct = await eax.encrypt(cipher, msgBytes, keyBytes, nonceBytes, openpgp.util.concatUint8Array([headerBytes, headerBytes, headerBytes]));
+      pt = await eax.decrypt(cipher, ct, keyBytes, nonceBytes, openpgp.util.concatUint8Array([headerBytes, headerBytes, headerBytes]));
+      expect(openpgp.util.Uint8Array_to_hex(pt)).to.equal(vec.msg.toLowerCase());
+    }
+  });
+}
+
+describe('Symmetric AES-EAX (native)', function() {
+  let use_nativeVal;
+  beforeEach(function() {
+    use_nativeVal = openpgp.config.use_native;
+    openpgp.config.use_native = true;
+  });
+  afterEach(function() {
+    openpgp.config.use_native = use_nativeVal;
+  });
+
+  testAESEAX();
+});
+
+describe('Symmetric AES-EAX (asm.js fallback)', function() {
+  let use_nativeVal;
+  beforeEach(function() {
+    use_nativeVal = openpgp.config.use_native;
+    openpgp.config.use_native = false;
+  });
+  afterEach(function() {
+    openpgp.config.use_native = use_nativeVal;
+  });
+
+  testAESEAX();
+});

--- a/test/crypto/elliptic.js
+++ b/test/crypto/elliptic.js
@@ -317,7 +317,7 @@ describe('Elliptic Curve Cryptography', function () {
           new Uint8Array(ephemeral),
           data,
           new Uint8Array(priv),
-          fingerprint
+          new Uint8Array(fingerprint)
         );
       });
     };
@@ -344,17 +344,17 @@ describe('Elliptic Curve Cryptography', function () {
 
     it('Invalid curve oid', function (done) {
       expect(decrypt_message(
-        '', 2, 7, [], [], [], ''
+        '', 2, 7, [], [], [], []
       )).to.be.rejectedWith(Error, /Not valid curve/).notify(done);
     });
     it('Invalid ephemeral key', function (done) {
       expect(decrypt_message(
-        'secp256k1', 2, 7, [], [], [], ''
+        'secp256k1', 2, 7, [], [], [], []
       )).to.be.rejectedWith(Error, /Unknown point format/).notify(done);
     });
     it('Invalid key data integrity', function (done) {
       expect(decrypt_message(
-        'secp256k1', 2, 7, secp256k1_value, secp256k1_point, secp256k1_data, ''
+        'secp256k1', 2, 7, secp256k1_value, secp256k1_point, secp256k1_data, []
       )).to.be.rejectedWith(Error, /Key Data Integrity failed/).notify(done);
     });
   });

--- a/test/crypto/index.js
+++ b/test/crypto/index.js
@@ -7,4 +7,5 @@ describe('Crypto', function () {
   require('./pkcs5.js');
   require('./aes_kw.js');
   require('./eax.js');
+  require('./ocb.js');
 });

--- a/test/crypto/index.js
+++ b/test/crypto/index.js
@@ -6,4 +6,5 @@ describe('Crypto', function () {
   require('./elliptic.js');
   require('./pkcs5.js');
   require('./aes_kw.js');
+  require('./eax.js');
 });

--- a/test/crypto/ocb.js
+++ b/test/crypto/ocb.js
@@ -1,0 +1,152 @@
+// Modified by ProtonTech AG
+
+// Adapted from https://github.com/artjomb/cryptojs-extension/blob/8c61d159/test/eax.js
+
+const openpgp = typeof window !== 'undefined' && window.openpgp ? window.openpgp : require('../../dist/openpgp');
+
+const chai = require('chai');
+chai.use(require('chai-as-promised'));
+
+const expect = chai.expect;
+
+const ocb = openpgp.crypto.ocb;
+
+describe('Symmetric AES-OCB', function() {
+  it('Passes all test vectors', async function() {
+    const K = '000102030405060708090A0B0C0D0E0F';
+    const keyBytes = openpgp.util.hex_to_Uint8Array(K);
+
+    var vectors = [
+      // From https://tools.ietf.org/html/rfc7253#appendix-A
+      {
+        N: 'BBAA99887766554433221100',
+        A: '',
+        P: '',
+        C: '785407BFFFC8AD9EDCC5520AC9111EE6'
+      },
+      {
+        N: 'BBAA99887766554433221101',
+        A: '0001020304050607',
+        P: '0001020304050607',
+        C: '6820B3657B6F615A5725BDA0D3B4EB3A257C9AF1F8F03009'
+      },
+      {
+        N: 'BBAA99887766554433221102',
+        A: '0001020304050607',
+        P: '',
+        C: '81017F8203F081277152FADE694A0A00'
+      },
+      {
+        N: 'BBAA99887766554433221103',
+        A: '',
+        P: '0001020304050607',
+        C: '45DD69F8F5AAE72414054CD1F35D82760B2CD00D2F99BFA9'
+      },
+      {
+        N: 'BBAA99887766554433221104',
+        A: '000102030405060708090A0B0C0D0E0F',
+        P: '000102030405060708090A0B0C0D0E0F',
+        C: '571D535B60B277188BE5147170A9A22C3AD7A4FF3835B8C5701C1CCEC8FC3358'
+      },
+      {
+        N: 'BBAA99887766554433221105',
+        A: '000102030405060708090A0B0C0D0E0F',
+        P: '',
+        C: '8CF761B6902EF764462AD86498CA6B97'
+      },
+      {
+        N: 'BBAA99887766554433221106',
+        A: '',
+        P: '000102030405060708090A0B0C0D0E0F',
+        C: '5CE88EC2E0692706A915C00AEB8B2396F40E1C743F52436BDF06D8FA1ECA343D'
+      },
+      {
+        N: 'BBAA99887766554433221107',
+        A: '000102030405060708090A0B0C0D0E0F1011121314151617',
+        P: '000102030405060708090A0B0C0D0E0F1011121314151617',
+        C: '1CA2207308C87C010756104D8840CE1952F09673A448A122C92C62241051F57356D7F3C90BB0E07F'
+      },
+      {
+        N: 'BBAA99887766554433221108',
+        A: '000102030405060708090A0B0C0D0E0F1011121314151617',
+        P: '',
+        C: '6DC225A071FC1B9F7C69F93B0F1E10DE'
+      },
+      {
+        N: 'BBAA99887766554433221109',
+        A: '',
+        P: '000102030405060708090A0B0C0D0E0F1011121314151617',
+        C: '221BD0DE7FA6FE993ECCD769460A0AF2D6CDED0C395B1C3CE725F32494B9F914D85C0B1EB38357FF'
+      },
+      {
+        N: 'BBAA9988776655443322110A',
+        A: '000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F',
+        P: '000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F',
+        C: 'BD6F6C496201C69296C11EFD138A467ABD3C707924B964DEAFFC40319AF5A48540FBBA186C5553C68AD9F592A79A4240'
+      },
+      {
+        N: 'BBAA9988776655443322110B',
+        A: '000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F',
+        P: '',
+        C: 'FE80690BEE8A485D11F32965BC9D2A32'
+      },
+      {
+        N: 'BBAA9988776655443322110C',
+        A: '',
+        P: '000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F',
+        C: '2942BFC773BDA23CABC6ACFD9BFD5835BD300F0973792EF46040C53F1432BCDFB5E1DDE3BC18A5F840B52E653444D5DF'
+      },
+      {
+        N: 'BBAA9988776655443322110D',
+        A: '000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627',
+        P: '000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627',
+        C: 'D5CA91748410C1751FF8A2F618255B68A0A12E093FF454606E59F9C1D0DDC54B65E8628E568BAD7AED07BA06A4A69483A7035490C5769E60'
+      },
+      {
+        N: 'BBAA9988776655443322110E',
+        A: '000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627',
+        P: '',
+        C: 'C5CD9D1850C141E358649994EE701B68'
+      },
+      {
+        N: 'BBAA9988776655443322110F',
+        A: '',
+        P: '000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627',
+        C: '4412923493C57D5DE0D700F753CCE0D1D2D95060122E9F15A5DDBFC5787E50B5CC55EE507BCB084E479AD363AC366B95A98CA5F3000B1479'
+      }
+    ];
+
+    const cipher = 'aes128';
+
+    for(const [i, vec] of vectors.entries()) {
+      const msgBytes = openpgp.util.hex_to_Uint8Array(vec.P),
+        nonceBytes = openpgp.util.hex_to_Uint8Array(vec.N),
+        headerBytes = openpgp.util.hex_to_Uint8Array(vec.A),
+        ctBytes = openpgp.util.hex_to_Uint8Array(vec.C);
+
+      // encryption test
+      let ct = await ocb.encrypt(cipher, msgBytes, keyBytes, nonceBytes, headerBytes);
+      expect(openpgp.util.Uint8Array_to_hex(ct)).to.equal(vec.C.toLowerCase());
+
+      // decryption test with verification
+      let pt = await ocb.decrypt(cipher, ctBytes, keyBytes, nonceBytes, headerBytes);
+      expect(openpgp.util.Uint8Array_to_hex(pt)).to.equal(vec.P.toLowerCase());
+
+      // tampering detection test
+      ct = await ocb.encrypt(cipher, msgBytes, keyBytes, nonceBytes, headerBytes);
+      ct[2] ^= 8;
+      pt = ocb.decrypt(cipher, ct, keyBytes, nonceBytes, headerBytes);
+      await expect(pt).to.eventually.be.rejectedWith('Authentication tag mismatch in OCB ciphertext')
+
+      // testing without additional data
+      ct = await ocb.encrypt(cipher, msgBytes, keyBytes, nonceBytes, new Uint8Array());
+      pt = await ocb.decrypt(cipher, ct, keyBytes, nonceBytes, new Uint8Array());
+      expect(openpgp.util.Uint8Array_to_hex(pt)).to.equal(vec.P.toLowerCase());
+
+      // testing with multiple additional data
+      ct = await ocb.encrypt(cipher, msgBytes, keyBytes, nonceBytes, openpgp.util.concatUint8Array([headerBytes, headerBytes, headerBytes]));
+      pt = await ocb.decrypt(cipher, ct, keyBytes, nonceBytes, openpgp.util.concatUint8Array([headerBytes, headerBytes, headerBytes]));
+      expect(openpgp.util.Uint8Array_to_hex(pt)).to.equal(vec.P.toLowerCase());
+    }
+  });
+});

--- a/test/crypto/ocb.js
+++ b/test/crypto/ocb.js
@@ -122,7 +122,7 @@ describe('Symmetric AES-OCB', function() {
         headerBytes = openpgp.util.hex_to_Uint8Array(vec.A),
         ctBytes = openpgp.util.hex_to_Uint8Array(vec.C);
 
-      const ocb = new openpgp.crypto.ocb(cipher, keyBytes);
+      const ocb = await openpgp.crypto.ocb(cipher, keyBytes);
 
       // encryption test
       let ct = await ocb.encrypt(msgBytes, nonceBytes, headerBytes);
@@ -162,7 +162,7 @@ describe('Symmetric AES-OCB', function() {
       const K = new Uint8Array(KEYLEN / 8);
       K[K.length - 1] = TAGLEN;
 
-      const ocb = new openpgp.crypto.ocb('aes' + KEYLEN, K);
+      const ocb = await openpgp.crypto.ocb('aes' + KEYLEN, K);
 
       const C = [];
       let N;

--- a/test/general/key.js
+++ b/test/general/key.js
@@ -1170,42 +1170,44 @@ p92yZgB3r2+f6/GIe2+7
     });
   });
 
-  it('getPreferredSymAlgo() - one key - AES256', async function() {
+  it("getPreferredAlgo('symmetric') - one key - AES256", async function() {
     const key1 = openpgp.key.readArmored(twoKeys).keys[0];
-    const prefAlgo = await openpgp.key.getPreferredSymAlgo([key1]);
+    const prefAlgo = await openpgp.key.getPreferredAlgo('symmetric', [key1]);
     expect(prefAlgo).to.equal(openpgp.enums.symmetric.aes256);
   });
 
-  it('getPreferredSymAlgo() - two key - AES128', async function() {
+  it("getPreferredAlgo('symmetric') - two key - AES128", async function() {
     const keys = openpgp.key.readArmored(twoKeys).keys;
     const key1 = keys[0];
     const key2 = keys[1];
     const primaryUser = await key2.getPrimaryUser();
     primaryUser.selfCertification.preferredSymmetricAlgorithms = [6,7,3];
-    const prefAlgo = await openpgp.key.getPreferredSymAlgo([key1, key2]);
+    const prefAlgo = await openpgp.key.getPreferredAlgo('symmetric', [key1, key2]);
     expect(prefAlgo).to.equal(openpgp.enums.symmetric.aes128);
   });
 
-  it('getPreferredSymAlgo() - two key - one without pref', async function() {
+  it("getPreferredAlgo('symmetric') - two key - one without pref", async function() {
     const keys = openpgp.key.readArmored(twoKeys).keys;
     const key1 = keys[0];
     const key2 = keys[1];
     const primaryUser = await key2.getPrimaryUser();
     primaryUser.selfCertification.preferredSymmetricAlgorithms = null;
-    const prefAlgo = await openpgp.key.getPreferredSymAlgo([key1, key2]);
+    const prefAlgo = await openpgp.key.getPreferredAlgo('symmetric', [key1, key2]);
     expect(prefAlgo).to.equal(openpgp.config.encryption_cipher);
   });
 
-  it('getPreferredAeadAlgo() - one key - OCB', async function() {
+  it("getPreferredAlgo('aead') - one key - OCB", async function() {
     const key1 = openpgp.key.readArmored(twoKeys).keys[0];
     const primaryUser = await key1.getPrimaryUser();
     primaryUser.selfCertification.features = [7]; // Monkey-patch AEAD feature flag
     primaryUser.selfCertification.preferredAeadAlgorithms = [2,1];
-    const prefAlgo = await openpgp.key.getPreferredAeadAlgo([key1]);
+    const prefAlgo = await openpgp.key.getPreferredAlgo('aead', [key1]);
     expect(prefAlgo).to.equal(openpgp.enums.aead.ocb);
+    const supported = await openpgp.key.isAeadSupported([key1]);
+    expect(supported).to.be.true;
   });
 
-  it('getPreferredAeadAlgo() - two key - one without pref', async function() {
+  it("getPreferredAlgo('aead') - two key - one without pref", async function() {
     const keys = openpgp.key.readArmored(twoKeys).keys;
     const key1 = keys[0];
     const key2 = keys[1];
@@ -1214,19 +1216,23 @@ p92yZgB3r2+f6/GIe2+7
     primaryUser.selfCertification.preferredAeadAlgorithms = [2,1];
     const primaryUser2 = await key2.getPrimaryUser();
     primaryUser2.selfCertification.features = [7]; // Monkey-patch AEAD feature flag
-    const prefAlgo = await openpgp.key.getPreferredAeadAlgo([key1, key2]);
+    const prefAlgo = await openpgp.key.getPreferredAlgo('aead', [key1, key2]);
     expect(prefAlgo).to.equal(openpgp.config.aead_mode);
+    const supported = await openpgp.key.isAeadSupported([key1, key2]);
+    expect(supported).to.be.true;
   });
 
-  it('getPreferredAeadAlgo() - two key - one with no support', async function() {
+  it("getPreferredAlgo('aead') - two key - one with no support", async function() {
     const keys = openpgp.key.readArmored(twoKeys).keys;
     const key1 = keys[0];
     const key2 = keys[1];
     const primaryUser = await key1.getPrimaryUser();
     primaryUser.selfCertification.features = [7]; // Monkey-patch AEAD feature flag
     primaryUser.selfCertification.preferredAeadAlgorithms = [2,1];
-    const prefAlgo = await openpgp.key.getPreferredAeadAlgo([key1, key2]);
-    expect(prefAlgo).to.be.null;
+    const prefAlgo = await openpgp.key.getPreferredAlgo('aead', [key1, key2]);
+    expect(prefAlgo).to.equal(openpgp.config.aead_mode);
+    const supported = await openpgp.key.isAeadSupported([key1, key2]);
+    expect(supported).to.be.false;
   });
 
   it('Preferences of generated key', function() {

--- a/test/general/key.js
+++ b/test/general/key.js
@@ -1228,7 +1228,7 @@ p92yZgB3r2+f6/GIe2+7
       expect(key.users[0].selfCertifications[0].preferredHashAlgorithms).to.eql([hash.sha256, hash.sha512, hash.sha1]);
       const compr = openpgp.enums.compression;
       expect(key.users[0].selfCertifications[0].preferredCompressionAlgorithms).to.eql([compr.zlib, compr.zip]);
-      expect(key.users[0].selfCertifications[0].features).to.eql(openpgp.config.integrity_protect ? [1] : null); // modification detection
+      expect(key.users[0].selfCertifications[0].features).to.eql(openpgp.config.aead_protect === 'draft04' ? [7] : [1]);
     };
     const opt = {numBits: 512, userIds: 'test <a@b.com>', passphrase: 'hello'};
     if (openpgp.util.getWebCryptoAll()) { opt.numBits = 2048; } // webkit webcrypto accepts minimum 2048 bit keys

--- a/test/general/key.js
+++ b/test/general/key.js
@@ -10,12 +10,16 @@ describe('Key', function() {
 
   describe('V5', function() {
     let aead_protectVal;
+    let aead_protect_versionVal;
     beforeEach(function() {
       aead_protectVal = openpgp.config.aead_protect;
-      openpgp.config.aead_protect = 'draft04';
+      aead_protect_versionVal = openpgp.config.aead_protect_version;
+      openpgp.config.aead_protect = true;
+      openpgp.config.aead_protect_version = 4;
     });
     afterEach(function() {
       openpgp.config.aead_protect = aead_protectVal;
+      openpgp.config.aead_protect_version = aead_protect_versionVal;
     });
 
     tests();
@@ -1220,7 +1224,7 @@ p92yZgB3r2+f6/GIe2+7
       expect(key.subKeys[0].bindingSignatures[0].keyFlags[0] & keyFlags.encrypt_storage).to.equal(keyFlags.encrypt_storage);
       const sym = openpgp.enums.symmetric;
       expect(key.users[0].selfCertifications[0].preferredSymmetricAlgorithms).to.eql([sym.aes256, sym.aes128, sym.aes192, sym.cast5, sym.tripledes]);
-      if (openpgp.config.aead_protect === 'draft04') {
+      if (openpgp.config.aead_protect && openpgp.config.aead_protect_version === 4) {
         const aead = openpgp.enums.aead;
         expect(key.users[0].selfCertifications[0].preferredAeadAlgorithms).to.eql([aead.eax, aead.ocb]);
       }
@@ -1228,7 +1232,7 @@ p92yZgB3r2+f6/GIe2+7
       expect(key.users[0].selfCertifications[0].preferredHashAlgorithms).to.eql([hash.sha256, hash.sha512, hash.sha1]);
       const compr = openpgp.enums.compression;
       expect(key.users[0].selfCertifications[0].preferredCompressionAlgorithms).to.eql([compr.zlib, compr.zip]);
-      expect(key.users[0].selfCertifications[0].features).to.eql(openpgp.config.aead_protect === 'draft04' ? [7] : [1]);
+      expect(key.users[0].selfCertifications[0].features).to.eql(openpgp.config.aead_protect && openpgp.config.aead_protect_version === 4 ? [7] : [1]);
     };
     const opt = {numBits: 512, userIds: 'test <a@b.com>', passphrase: 'hello'};
     if (openpgp.util.getWebCryptoAll()) { opt.numBits = 2048; } // webkit webcrypto accepts minimum 2048 bit keys

--- a/test/general/key.js
+++ b/test/general/key.js
@@ -1199,6 +1199,7 @@ p92yZgB3r2+f6/GIe2+7
   it('getPreferredAeadAlgo() - one key - OCB', async function() {
     const key1 = openpgp.key.readArmored(twoKeys).keys[0];
     const primaryUser = await key1.getPrimaryUser();
+    primaryUser.selfCertification.features = [7]; // Monkey-patch AEAD feature flag
     primaryUser.selfCertification.preferredAeadAlgorithms = [2,1];
     const prefAlgo = await openpgp.key.getPreferredAeadAlgo([key1]);
     expect(prefAlgo).to.equal(openpgp.enums.aead.ocb);
@@ -1209,9 +1210,23 @@ p92yZgB3r2+f6/GIe2+7
     const key1 = keys[0];
     const key2 = keys[1];
     const primaryUser = await key1.getPrimaryUser();
+    primaryUser.selfCertification.features = [7]; // Monkey-patch AEAD feature flag
     primaryUser.selfCertification.preferredAeadAlgorithms = [2,1];
+    const primaryUser2 = await key2.getPrimaryUser();
+    primaryUser2.selfCertification.features = [7]; // Monkey-patch AEAD feature flag
     const prefAlgo = await openpgp.key.getPreferredAeadAlgo([key1, key2]);
     expect(prefAlgo).to.equal(openpgp.config.aead_mode);
+  });
+
+  it('getPreferredAeadAlgo() - two key - one with no support', async function() {
+    const keys = openpgp.key.readArmored(twoKeys).keys;
+    const key1 = keys[0];
+    const key2 = keys[1];
+    const primaryUser = await key1.getPrimaryUser();
+    primaryUser.selfCertification.features = [7]; // Monkey-patch AEAD feature flag
+    primaryUser.selfCertification.preferredAeadAlgorithms = [2,1];
+    const prefAlgo = await openpgp.key.getPreferredAeadAlgo([key1, key2]);
+    expect(prefAlgo).to.be.null;
   });
 
   it('Preferences of generated key', function() {

--- a/test/general/openpgp.js
+++ b/test/general/openpgp.js
@@ -667,6 +667,22 @@ describe('OpenPGP.js public api tests', function() {
       }
     });
 
+    tryTests('EAX mode (asm.js)', tests, {
+      if: true,
+      beforeEach: function() {
+        openpgp.config.use_native = false;
+        openpgp.config.aead_protect = 'draft04';
+      }
+    });
+
+    tryTests('EAX mode (native)', tests, {
+      if: openpgp.util.getWebCryptoAll() || openpgp.util.getNodeCrypto(),
+      beforeEach: function() {
+        openpgp.config.use_native = true;
+        openpgp.config.aead_protect = 'draft04';
+      }
+    });
+
     function tests() {
       it('Configuration', function() {
         openpgp.config.show_version = false;

--- a/test/general/openpgp.js
+++ b/test/general/openpgp.js
@@ -674,6 +674,36 @@ describe('OpenPGP.js public api tests', function() {
       }
     });
 
+    tryTests('GCM mode (draft04, asm.js)', tests, {
+      if: openpgp.util.getWebCrypto() || openpgp.util.getNodeCrypto(),
+      beforeEach: function() {
+        openpgp.config.use_native = false;
+        openpgp.config.aead_protect = true;
+        openpgp.config.aead_protect_version = 4;
+        openpgp.config.aead_mode = openpgp.enums.aead.gcm;
+
+        // Monkey-patch AEAD feature flag
+        publicKey.keys[0].users[0].selfCertifications[0].features = [7];
+        publicKey_2000_2008.keys[0].users[0].selfCertifications[0].features = [7];
+        publicKey_2038_2045.keys[0].users[0].selfCertifications[0].features = [7];
+      }
+    });
+
+    tryTests('GCM mode (draft04, native)', tests, {
+      if: openpgp.util.getWebCrypto() || openpgp.util.getNodeCrypto(),
+      beforeEach: function() {
+        openpgp.config.use_native = true;
+        openpgp.config.aead_protect = true;
+        openpgp.config.aead_protect_version = 4;
+        openpgp.config.aead_mode = openpgp.enums.aead.gcm;
+
+        // Monkey-patch AEAD feature flag
+        publicKey.keys[0].users[0].selfCertifications[0].features = [7];
+        publicKey_2000_2008.keys[0].users[0].selfCertifications[0].features = [7];
+        publicKey_2038_2045.keys[0].users[0].selfCertifications[0].features = [7];
+      }
+    });
+
     tryTests('EAX mode (asm.js)', tests, {
       if: true,
       beforeEach: function() {

--- a/test/general/openpgp.js
+++ b/test/general/openpgp.js
@@ -598,6 +598,7 @@ describe('OpenPGP.js public api tests', function() {
     let use_nativeVal;
     let aead_protectVal;
     let aead_protect_versionVal;
+    let aead_modeVal;
 
     beforeEach(function(done) {
       publicKey = openpgp.key.readArmored(pub_key);
@@ -622,6 +623,7 @@ describe('OpenPGP.js public api tests', function() {
       use_nativeVal = openpgp.config.use_native;
       aead_protectVal = openpgp.config.aead_protect;
       aead_protect_versionVal = openpgp.config.aead_protect_version;
+      aead_modeVal = openpgp.config.aead_mode;
       done();
     });
 
@@ -630,6 +632,7 @@ describe('OpenPGP.js public api tests', function() {
       openpgp.config.use_native = use_nativeVal;
       openpgp.config.aead_protect = aead_protectVal;
       openpgp.config.aead_protect_version = aead_protect_versionVal;
+      openpgp.config.aead_mode = aead_modeVal;
     });
 
     it('Decrypting key with wrong passphrase rejected', async function () {
@@ -685,6 +688,15 @@ describe('OpenPGP.js public api tests', function() {
         openpgp.config.use_native = true;
         openpgp.config.aead_protect = true;
         openpgp.config.aead_protect_version = 4;
+      }
+    });
+
+    tryTests('OCB mode', tests, {
+      if: true,
+      beforeEach: function() {
+        openpgp.config.aead_protect = true;
+        openpgp.config.aead_protect_version = 4;
+        openpgp.config.aead_mode = openpgp.enums.aead.ocb;
       }
     });
 

--- a/test/general/openpgp.js
+++ b/test/general/openpgp.js
@@ -599,6 +599,7 @@ describe('OpenPGP.js public api tests', function() {
     let aead_protectVal;
     let aead_protect_versionVal;
     let aead_modeVal;
+    let aead_chunk_size_byteVal;
 
     beforeEach(function(done) {
       publicKey = openpgp.key.readArmored(pub_key);
@@ -625,6 +626,7 @@ describe('OpenPGP.js public api tests', function() {
       aead_protectVal = openpgp.config.aead_protect;
       aead_protect_versionVal = openpgp.config.aead_protect_version;
       aead_modeVal = openpgp.config.aead_mode;
+      aead_chunk_size_byteVal = openpgp.config.aead_chunk_size_byte;
       done();
     });
 
@@ -634,6 +636,7 @@ describe('OpenPGP.js public api tests', function() {
       openpgp.config.aead_protect = aead_protectVal;
       openpgp.config.aead_protect_version = aead_protect_versionVal;
       openpgp.config.aead_mode = aead_modeVal;
+      openpgp.config.aead_chunk_size_byte = aead_chunk_size_byteVal;
     });
 
     it('Decrypting key with wrong passphrase rejected', async function () {
@@ -724,6 +727,21 @@ describe('OpenPGP.js public api tests', function() {
         openpgp.config.use_native = true;
         openpgp.config.aead_protect = true;
         openpgp.config.aead_protect_version = 4;
+
+        // Monkey-patch AEAD feature flag
+        publicKey.keys[0].users[0].selfCertifications[0].features = [7];
+        publicKey_2000_2008.keys[0].users[0].selfCertifications[0].features = [7];
+        publicKey_2038_2045.keys[0].users[0].selfCertifications[0].features = [7];
+      }
+    });
+
+    tryTests('EAX mode (small chunk size)', tests, {
+      if: openpgp.util.getWebCryptoAll() || openpgp.util.getNodeCrypto(),
+      beforeEach: function() {
+        openpgp.config.use_native = true;
+        openpgp.config.aead_protect = true;
+        openpgp.config.aead_protect_version = 4;
+        openpgp.config.aead_chunk_size_byte = 0;
 
         // Monkey-patch AEAD feature flag
         publicKey.keys[0].users[0].selfCertifications[0].features = [7];

--- a/test/general/openpgp.js
+++ b/test/general/openpgp.js
@@ -597,6 +597,7 @@ describe('OpenPGP.js public api tests', function() {
     let zero_copyVal;
     let use_nativeVal;
     let aead_protectVal;
+    let aead_protect_versionVal;
 
     beforeEach(function(done) {
       publicKey = openpgp.key.readArmored(pub_key);
@@ -620,6 +621,7 @@ describe('OpenPGP.js public api tests', function() {
       zero_copyVal = openpgp.config.zero_copy;
       use_nativeVal = openpgp.config.use_native;
       aead_protectVal = openpgp.config.aead_protect;
+      aead_protect_versionVal = openpgp.config.aead_protect_version;
       done();
     });
 
@@ -627,6 +629,7 @@ describe('OpenPGP.js public api tests', function() {
       openpgp.config.zero_copy = zero_copyVal;
       openpgp.config.use_native = use_nativeVal;
       openpgp.config.aead_protect = aead_protectVal;
+      openpgp.config.aead_protect_version = aead_protect_versionVal;
     });
 
     it('Decrypting key with wrong passphrase rejected', async function () {
@@ -671,7 +674,8 @@ describe('OpenPGP.js public api tests', function() {
       if: true,
       beforeEach: function() {
         openpgp.config.use_native = false;
-        openpgp.config.aead_protect = 'draft04';
+        openpgp.config.aead_protect = true;
+        openpgp.config.aead_protect_version = 4;
       }
     });
 
@@ -679,7 +683,8 @@ describe('OpenPGP.js public api tests', function() {
       if: openpgp.util.getWebCryptoAll() || openpgp.util.getNodeCrypto(),
       beforeEach: function() {
         openpgp.config.use_native = true;
-        openpgp.config.aead_protect = 'draft04';
+        openpgp.config.aead_protect = true;
+        openpgp.config.aead_protect_version = 4;
       }
     });
 

--- a/test/general/openpgp.js
+++ b/test/general/openpgp.js
@@ -858,6 +858,30 @@ describe('OpenPGP.js public api tests', function() {
           });
         });
 
+        it('roundtrip workflow: encrypt, decryptSessionKeys, decrypt with pgp key pair -- trailing spaces', function () {
+          const plaintext = 'space: \nspace and tab: \t\nno trailing space\n  \ntab:\t\ntab and space:\t ';
+          let msgAsciiArmored;
+          return openpgp.encrypt({
+            data: plaintext,
+            publicKeys: publicKey.keys
+          }).then(function (encrypted) {
+            msgAsciiArmored = encrypted.data;
+            return openpgp.decryptSessionKeys({
+              message: openpgp.message.readArmored(msgAsciiArmored),
+              privateKeys: privateKey.keys[0]
+            });
+
+          }).then(function (decryptedSessionKeys) {
+            const message = openpgp.message.readArmored(msgAsciiArmored);
+            return openpgp.decrypt({
+              sessionKeys: decryptedSessionKeys[0],
+              message
+            });
+          }).then(function (decrypted) {
+            expect(decrypted.data).to.equal(plaintext);
+          });
+        });
+
         it('roundtrip workflow: encrypt, decryptSessionKeys, decrypt with password', function () {
           let msgAsciiArmored;
           return openpgp.encrypt({

--- a/test/general/packet.js
+++ b/test/general/packet.js
@@ -89,7 +89,7 @@ describe("Packet", function() {
     message.push(enc);
     await enc.packets.push(literal);
 
-    const key = '12345678901234567890123456789012';
+    const key = new Uint8Array([1,2,3,4,5,6,7,8,9,0,1,2,3,4,5,6,7,8,9,0,1,2,3,4,5,6,7,8,9,0,1,2]);
     const algo = 'aes256';
 
     await enc.encrypt(algo, key);

--- a/test/general/packet.js
+++ b/test/general/packet.js
@@ -144,7 +144,9 @@ describe("Packet", function() {
 
   it('Sym. encrypted AEAD protected packet (draft04)', function() {
     let aead_protectVal = openpgp.config.aead_protect;
-    openpgp.config.aead_protect = 'draft04';
+    let aead_protect_versionVal = openpgp.config.aead_protect_version;
+    openpgp.config.aead_protect = true;
+    openpgp.config.aead_protect_version = 4;
 
     const key = new Uint8Array([1,2,3,4,5,6,7,8,9,0,1,2,3,4,5,6,7,8,9,0,1,2,3,4,5,6,7,8,9,0,1,2]);
     const algo = 'aes256';
@@ -166,6 +168,7 @@ describe("Packet", function() {
       expect(msg2[0].packets[0].data).to.deep.equal(literal.data);
     }).finally(function() {
       openpgp.config.aead_protect = aead_protectVal;
+      openpgp.config.aead_protect_version = aead_protect_versionVal;
     });
   });
 
@@ -181,8 +184,10 @@ describe("Packet", function() {
     `.replace(/\s+/g, ''));
 
     let aead_protectVal = openpgp.config.aead_protect;
+    let aead_protect_versionVal = openpgp.config.aead_protect_version;
     let aead_chunk_size_byteVal = openpgp.config.aead_chunk_size_byte;
-    openpgp.config.aead_protect = 'draft04';
+    openpgp.config.aead_protect = true;
+    openpgp.config.aead_protect_version = 4;
     openpgp.config.aead_chunk_size_byte = 14;
 
     const iv = openpgp.util.hex_to_Uint8Array('b7 32 37 9f 73 c4 92 8d e2 5f ac fe 65 17 ec 10'.replace(/\s+/g, ''));
@@ -212,6 +217,7 @@ describe("Packet", function() {
       expect(msg2[0].packets[0].data).to.deep.equal(literal.data);
     }).finally(function() {
       openpgp.config.aead_protect = aead_protectVal;
+      openpgp.config.aead_protect_version = aead_protect_versionVal;
       openpgp.config.aead_chunk_size_byte = aead_chunk_size_byteVal;
       randomBytesStub.restore();
     });
@@ -417,7 +423,9 @@ describe("Packet", function() {
 
   it('Sym. encrypted session key reading/writing (draft04)', async function() {
     let aead_protectVal = openpgp.config.aead_protect;
-    openpgp.config.aead_protect = 'draft04';
+    let aead_protect_versionVal = openpgp.config.aead_protect_version;
+    openpgp.config.aead_protect = true;
+    openpgp.config.aead_protect_version = 4;
 
     try {
       const passphrase = 'hello';
@@ -450,6 +458,7 @@ describe("Packet", function() {
       expect(stringify(msg2[1].packets[0].data)).to.equal(stringify(literal.data));
     } finally {
       openpgp.config.aead_protect = aead_protectVal;
+      openpgp.config.aead_protect_version = aead_protect_versionVal;
     }
   });
 
@@ -457,9 +466,11 @@ describe("Packet", function() {
     // From https://gitlab.com/openpgp-wg/rfc4880bis/blob/00b20923/back.mkd#sample-aead-eax-encryption-and-decryption
 
     let aead_protectVal = openpgp.config.aead_protect;
+    let aead_protect_versionVal = openpgp.config.aead_protect_version;
     let aead_chunk_size_byteVal = openpgp.config.aead_chunk_size_byte;
     let s2k_iteration_count_byteVal = openpgp.config.s2k_iteration_count_byte;
-    openpgp.config.aead_protect = 'draft04';
+    openpgp.config.aead_protect = true;
+    openpgp.config.aead_protect_version = 4;
     openpgp.config.aead_chunk_size_byte = 14;
     openpgp.config.s2k_iteration_count_byte = 0x90;
 
@@ -522,6 +533,7 @@ describe("Packet", function() {
       expect(stringify(msg2[1].packets[0].data)).to.equal(stringify(literal.data));
     } finally {
       openpgp.config.aead_protect = aead_protectVal;
+      openpgp.config.aead_protect_version = aead_protect_versionVal;
       openpgp.config.aead_chunk_size_byte = aead_chunk_size_byteVal;
       openpgp.config.s2k_iteration_count_byte = s2k_iteration_count_byteVal;
       randomBytesStub.restore();
@@ -532,9 +544,11 @@ describe("Packet", function() {
     // From https://gitlab.com/openpgp-wg/rfc4880bis/blob/00b20923/back.mkd#sample-aead-ocb-encryption-and-decryption
 
     let aead_protectVal = openpgp.config.aead_protect;
+    let aead_protect_versionVal = openpgp.config.aead_protect_version;
     let aead_chunk_size_byteVal = openpgp.config.aead_chunk_size_byte;
     let s2k_iteration_count_byteVal = openpgp.config.s2k_iteration_count_byte;
-    openpgp.config.aead_protect = 'draft04';
+    openpgp.config.aead_protect = true;
+    openpgp.config.aead_protect_version = 4;
     openpgp.config.aead_chunk_size_byte = 14;
     openpgp.config.s2k_iteration_count_byte = 0x90;
 
@@ -598,6 +612,7 @@ describe("Packet", function() {
       expect(stringify(msg2[1].packets[0].data)).to.equal(stringify(literal.data));
     } finally {
       openpgp.config.aead_protect = aead_protectVal;
+      openpgp.config.aead_protect_version = aead_protect_versionVal;
       openpgp.config.aead_chunk_size_byte = aead_chunk_size_byteVal;
       openpgp.config.s2k_iteration_count_byte = s2k_iteration_count_byteVal;
       randomBytesStub.restore();
@@ -715,7 +730,9 @@ describe("Packet", function() {
 
   it('Writing and encryption of a secret key packet. (draft04)', function() {
     let aead_protectVal = openpgp.config.aead_protect;
-    openpgp.config.aead_protect = 'draft04';
+    let aead_protect_versionVal = openpgp.config.aead_protect_version;
+    openpgp.config.aead_protect = true;
+    openpgp.config.aead_protect_version = 4;
 
     const key = new openpgp.packet.List();
     key.push(new openpgp.packet.SecretKey());
@@ -742,6 +759,7 @@ describe("Packet", function() {
       expect(key[0].params.toString()).to.equal(key2[0].params.toString());
     }).finally(function() {
       openpgp.config.aead_protect = aead_protectVal;
+      openpgp.config.aead_protect_version = aead_protect_versionVal;
     });
   });
 

--- a/test/general/packet.js
+++ b/test/general/packet.js
@@ -453,8 +453,8 @@ describe("Packet", function() {
     }
   });
 
-  it('Sym. encrypted session key reading/writing test vector (draft04)', async function() {
-    // From https://gitlab.com/openpgp-wg/rfc4880bis/commit/00b20923e6233fb6ff1666ecd5acfefceb32907d
+  it('Sym. encrypted session key reading/writing test vector (EAX, draft04)', async function() {
+    // From https://gitlab.com/openpgp-wg/rfc4880bis/blob/00b20923/back.mkd#sample-aead-eax-encryption-and-decryption
 
     let aead_protectVal = openpgp.config.aead_protect;
     let aead_chunk_size_byteVal = openpgp.config.aead_chunk_size_byte;
@@ -495,6 +495,82 @@ describe("Packet", function() {
       const key_enc = new openpgp.packet.SymEncryptedSessionKey();
       const enc = new openpgp.packet.SymEncryptedAEADProtected();
       const msg = new openpgp.packet.List();
+
+      msg.push(key_enc);
+      msg.push(enc);
+
+      key_enc.sessionKeyAlgorithm = algo;
+      await key_enc.encrypt(passphrase);
+
+      const key = key_enc.sessionKey;
+
+      literal.setBytes(openpgp.util.str_to_Uint8Array('Hello, world!\n'), openpgp.enums.literal.binary);
+      literal.filename = '';
+      enc.packets.push(literal);
+      await enc.encrypt(algo, key);
+
+      const data = msg.write();
+      expect(data).to.deep.equal(packetBytes);
+
+      const msg2 = new openpgp.packet.List();
+      msg2.read(data);
+
+      await msg2[0].decrypt(passphrase);
+      const key2 = msg2[0].sessionKey;
+      await msg2[1].decrypt(msg2[0].sessionKeyAlgorithm, key2);
+
+      expect(stringify(msg2[1].packets[0].data)).to.equal(stringify(literal.data));
+    } finally {
+      openpgp.config.aead_protect = aead_protectVal;
+      openpgp.config.aead_chunk_size_byte = aead_chunk_size_byteVal;
+      openpgp.config.s2k_iteration_count_byte = s2k_iteration_count_byteVal;
+      randomBytesStub.restore();
+    }
+  });
+
+  it('Sym. encrypted session key reading/writing test vector (OCB, draft04)', async function() {
+    // From https://gitlab.com/openpgp-wg/rfc4880bis/blob/00b20923/back.mkd#sample-aead-ocb-encryption-and-decryption
+
+    let aead_protectVal = openpgp.config.aead_protect;
+    let aead_chunk_size_byteVal = openpgp.config.aead_chunk_size_byte;
+    let s2k_iteration_count_byteVal = openpgp.config.s2k_iteration_count_byte;
+    openpgp.config.aead_protect = 'draft04';
+    openpgp.config.aead_chunk_size_byte = 14;
+    openpgp.config.s2k_iteration_count_byte = 0x90;
+
+    let salt = openpgp.util.hex_to_Uint8Array(`9f0b7da3e5ea6477`);
+    let sessionKey = openpgp.util.hex_to_Uint8Array(`d1 f0 1b a3 0e 13 0a a7 d2 58 2c 16 e0 50 ae 44`.replace(/\s+/g, ''));
+    let sessionIV = openpgp.util.hex_to_Uint8Array(`99 e3 26 e5 40 0a 90 93 6c ef b4 e8 eb a0 8c`.replace(/\s+/g, ''));
+    let dataIV = openpgp.util.hex_to_Uint8Array(`5e d2 bc 1e 47 0a be 8f 1d 64 4c 7a 6c 8a 56`.replace(/\s+/g, ''));
+
+    let randomBytesStub = stub(openpgp.crypto.random, 'getRandomBytes');
+    randomBytesStub.onCall(0).returns(resolves(salt));
+    randomBytesStub.onCall(1).returns(resolves(sessionKey));
+    randomBytesStub.onCall(2).returns(resolves(sessionIV));
+    randomBytesStub.onCall(3).returns(resolves(dataIV));
+
+    let packetBytes = openpgp.util.hex_to_Uint8Array(`
+      c3 3d 05 07 02 03 08 9f  0b 7d a3 e5 ea 64 77 90
+      99 e3 26 e5 40 0a 90 93  6c ef b4 e8 eb a0 8c 67
+      73 71 6d 1f 27 14 54 0a  38 fc ac 52 99 49 da c5
+      29 d3 de 31 e1 5b 4a eb  72 9e 33 00 33 db ed
+
+      d4 49 01 07 02 0e 5e d2  bc 1e 47 0a be 8f 1d 64
+      4c 7a 6c 8a 56 7b 0f 77  01 19 66 11 a1 54 ba 9c
+      25 74 cd 05 62 84 a8 ef  68 03 5c 62 3d 93 cc 70
+      8a 43 21 1b b6 ea f2 b2  7f 7c 18 d5 71 bc d8 3b
+      20 ad d3 a0 8b 73 af 15  b9 a0 98
+    `.replace(/\s+/g, ''));
+
+    try {
+      const passphrase = 'password';
+      const algo = 'aes128';
+
+      const literal = new openpgp.packet.Literal(0);
+      const key_enc = new openpgp.packet.SymEncryptedSessionKey();
+      const enc = new openpgp.packet.SymEncryptedAEADProtected();
+      const msg = new openpgp.packet.List();
+      enc.aeadAlgorithm = key_enc.aeadAlgorithm = 'ocb';
 
       msg.push(key_enc);
       msg.push(enc);

--- a/test/general/packet.js
+++ b/test/general/packet.js
@@ -269,13 +269,13 @@ describe("Packet", function() {
       enc.publicKeyAlgorithm = 'rsa_encrypt';
       enc.sessionKeyAlgorithm = 'aes256';
       enc.publicKeyId.bytes = '12345678';
-      return enc.encrypt({ params: mpi }).then(() => {
+      return enc.encrypt({ params: mpi, getFingerprintBytes() {} }).then(() => {
 
         msg.push(enc);
 
         msg2.read(msg.write());
 
-        return msg2[0].decrypt({ params: mpi }).then(() => {
+        return msg2[0].decrypt({ params: mpi, getFingerprintBytes() {} }).then(() => {
 
           expect(stringify(msg2[0].sessionKey)).to.equal(stringify(enc.sessionKey));
           expect(msg2[0].sessionKeyAlgorithm).to.equal(enc.sessionKeyAlgorithm);

--- a/test/general/signature.js
+++ b/test/general/signature.js
@@ -580,6 +580,75 @@ describe("Signature", function() {
     });
   });
 
+  it('Verify cleartext signed message with trailing spaces from GPG', function() {
+    const msg_armor =
+      `-----BEGIN PGP SIGNED MESSAGE-----
+Hash: SHA1
+
+space: 
+space and tab: \t
+no trailing space
+  
+tab:\t
+tab and space:\t 
+-----BEGIN PGP SIGNATURE-----
+Version: GnuPG v1
+
+iJwEAQECAAYFAlrZzCQACgkQ4IT3RGwgLJeWggP+Pb33ubbELIzg9/imM+zlR063
+g0FbG4B+RGZNFSbaDArUgh9fdVqBy8M9vvbbDMBalSiQxY09Lrasfb+tsomrygbN
+NisuPRa5phPhn1bB4hZDb2ed/iK41CNyU7QHuv4AAvLC0mMamRnEg0FW2M2jZLGh
+zmuVOdNuWQqxT9Sqa84=
+=bqAR
+-----END PGP SIGNATURE-----`;
+
+    const plaintext = 'space: \nspace and tab: \t\nno trailing space\n  \ntab:\t\ntab and space:\t ';
+    const csMsg = openpgp.cleartext.readArmored(msg_armor);
+    const pubKey = openpgp.key.readArmored(pub_key_arm2).keys[0];
+
+    const keyids = csMsg.getSigningKeyIds();
+
+    expect(pubKey.getKeyPackets(keyids[0])).to.not.be.empty;
+
+    return openpgp.verify({ publicKeys:[pubKey], message:csMsg }).then(function(cleartextSig) {
+      expect(cleartextSig).to.exist;
+      expect(cleartextSig.data).to.equal(openpgp.util.removeTrailingSpaces(plaintext));
+      expect(cleartextSig.signatures).to.have.length(1);
+      expect(cleartextSig.signatures[0].valid).to.be.true;
+      expect(cleartextSig.signatures[0].signature.packets.length).to.equal(1);
+    });
+  });
+
+  it('Verify signed message with trailing spaces from GPG', function() {
+    const msg_armor =
+      `-----BEGIN PGP MESSAGE-----
+Version: GnuPG v1
+
+owGbwMvMyMT4oOW7S46CznTG01El3MUFicmpxbolqcUlUTev14K5Vgq8XGCGQmJe
+ikJJYpKVAicvV16+QklRYmZOZl66AliWl0sBqBAkzQmmwKohBnAqdMxhYWRkYmBj
+ZQIZy8DFKQCztusM8z+Vt/svG80IS/etn90utv/T16jquk69zPvp6t9F16ryrwpb
+kfVlS5Xl38KnVYxWvIor0nao6WUczA4vvZX9TXPWnnW3tt1vbZoiqWUjYjjjhuKG
+4DtmMTuL3TW6/zNzVfWp/Q11+71O8RGnXMsBvWM6mSqX75uLiPo6HRaUDHnvrfCP
+yYDnCgA=
+=15ki
+-----END PGP MESSAGE-----`;
+
+    const plaintext = 'space: \nspace and tab: \t\nno trailing space\n  \ntab:\t\ntab and space:\t ';
+    const sMsg = openpgp.message.readArmored(msg_armor);
+    const pubKey = openpgp.key.readArmored(pub_key_arm2).keys[0];
+
+    const keyids = sMsg.getSigningKeyIds();
+
+    expect(pubKey.getKeyPackets(keyids[0])).to.not.be.empty;
+
+    return openpgp.verify({ publicKeys:[pubKey], message:sMsg }).then(function(cleartextSig) {
+      expect(cleartextSig).to.exist;
+      expect(openpgp.util.nativeEOL(openpgp.util.Uint8Array_to_str(cleartextSig.data))).to.equal(plaintext);
+      expect(cleartextSig.signatures).to.have.length(1);
+      expect(cleartextSig.signatures[0].valid).to.be.true;
+      expect(cleartextSig.signatures[0].signature.packets.length).to.equal(1);
+    });
+  });
+
   it('Sign text with openpgp.sign and verify with openpgp.verify leads to same string cleartext and valid signatures', async function() {
     const plaintext = 'short message\nnext line\n한국어/조선말';
     const pubKey = openpgp.key.readArmored(pub_key_arm2).keys[0];
@@ -594,6 +663,26 @@ describe("Signature", function() {
     }).then(function(cleartextSig) {
       expect(cleartextSig).to.exist;
       expect(cleartextSig.data).to.equal(plaintext.replace(/\r/g,''));
+      expect(cleartextSig.signatures).to.have.length(1);
+      expect(cleartextSig.signatures[0].valid).to.be.true;
+      expect(cleartextSig.signatures[0].signature.packets.length).to.equal(1);
+    });
+  });
+
+  it('Sign text with openpgp.sign and verify with openpgp.verify leads to same string cleartext and valid signatures -- trailing spaces', async function() {
+    const plaintext = 'space: \nspace and tab: \t\nno trailing space\n  \ntab:\t\ntab and space:\t ';
+    const pubKey = openpgp.key.readArmored(pub_key_arm2).keys[0];
+    const privKey = openpgp.key.readArmored(priv_key_arm2).keys[0];
+    await privKey.primaryKey.decrypt('hello world');
+
+    return openpgp.sign({ privateKeys:[privKey], data:plaintext }).then(function(signed) {
+
+      const csMsg = openpgp.cleartext.readArmored(signed.data);
+      return openpgp.verify({ publicKeys:[pubKey], message:csMsg });
+
+    }).then(function(cleartextSig) {
+      expect(cleartextSig).to.exist;
+      expect(cleartextSig.data).to.equal(openpgp.util.removeTrailingSpaces(plaintext));
       expect(cleartextSig.signatures).to.have.length(1);
       expect(cleartextSig.signatures[0].valid).to.be.true;
       expect(cleartextSig.signatures[0].signature.packets.length).to.equal(1);

--- a/test/general/signature.js
+++ b/test/general/signature.js
@@ -689,6 +689,26 @@ yYDnCgA=
     });
   });
 
+  it('Sign text with openpgp.sign and verify with openpgp.verify leads to same string cleartext and valid signatures -- escape armored message', async function() {
+    const plaintext = pub_key_arm2;
+    const pubKey = openpgp.key.readArmored(pub_key_arm2).keys[0];
+    const privKey = openpgp.key.readArmored(priv_key_arm2).keys[0];
+    await privKey.primaryKey.decrypt('hello world');
+
+    return openpgp.sign({ privateKeys:[privKey], data:plaintext }).then(function(signed) {
+
+      const csMsg = openpgp.cleartext.readArmored(signed.data);
+      return openpgp.verify({ publicKeys:[pubKey], message:csMsg });
+
+    }).then(function(cleartextSig) {
+      expect(cleartextSig).to.exist;
+      expect(cleartextSig.data).to.equal(plaintext);
+      expect(cleartextSig.signatures).to.have.length(1);
+      expect(cleartextSig.signatures[0].valid).to.be.true;
+      expect(cleartextSig.signatures[0].signature.packets.length).to.equal(1);
+    });
+  });
+
   it('Sign text with openpgp.sign and verify with openpgp.verify leads to same bytes cleartext and valid signatures - armored', async function() {
     const plaintext = openpgp.util.str_to_Uint8Array('short message\nnext line\n한국어/조선말');
     const pubKey = openpgp.key.readArmored(pub_key_arm2).keys[0];

--- a/test/unittests.js
+++ b/test/unittests.js
@@ -32,7 +32,13 @@ if (typeof Promise === 'undefined') {
 
 describe('Unit Tests', function () {
 
-  if (typeof window !== 'undefined') { afterEach(function () { window.scrollTo(0, document.body.scrollHeight); }); }
+  if (typeof window !== 'undefined') {
+    afterEach(function () {
+      if (window.scrollY >= document.body.scrollHeight - window.innerHeight - 100) {
+        window.scrollTo(0, document.body.scrollHeight);
+      }
+    });
+  }
 
   require('./crypto');
   require('./general');

--- a/test/unittests.js
+++ b/test/unittests.js
@@ -38,6 +38,13 @@ describe('Unit Tests', function () {
         window.scrollTo(0, document.body.scrollHeight);
       }
     });
+
+    window.location.search.substr(1).split('&').forEach(param => {
+      const [key, value] = param.split('=');
+      if (key && key !== 'grep') {
+        openpgp.config[key] = JSON.parse(value);
+      }
+    });
   }
 
   require('./crypto');


### PR DESCRIPTION
Implementation Notes
=============================================================================================================================

  

  

Native AES-EAX
--------------

  

Native Web Crypto and Node Crypto do not support AES-EAX, but they do support AES-CTR, which AES-EAX is built upon. Therefore, I've implemented EAX in a way that is agnostic to the underlying CTR implementation, and automatically selects native CTR whenever available.

  

Similarly, EAX also makes use of CMAC, which in turn makes use of CBC, which is supported by Web and Node Crypto, so I've made use of that as well.

  

EAX mode itself (as opposed to AES-EAX) does not require AES and is flexible enough to be used with any block cipher, but RFC4880bis-04 only mandates support for AES-128. We support AES-{128, 192, 256} (although AES-192 is not supported by Web Crypto in Chrome).

  

A note on implementing a draft specification
--------------------------------------------

  

RFC4880bis-04 is a work in progress and may change at any time, and any implementation of it should be considered as such as well. The OpenPGP.js documentation already did a good job of making users aware that enabling AEAD may break compatibility with other implementations, but I have now also added a warning that future versions of OpenPGP.js may break compatibility with it, as well.

  

Backwards compatibility
-----------------------

  

Unfortunately, RFC4880bis-04 is already incompatible with our current implementation of the previous draft: for example, the AEAD Encrypted Data Packet has gained fields for the cipher algorithm, AEAD algorithm, and chunk size.

  

A look at [GitHub code search reveals](https://github.com/search?q=openpgp.config.aead_protect+%3D+true&type=Code&utf8=%E2%9C%93) that `aead_protect` is actually used quite a lot, even in apps that store encrypted PGP messages on disk or present them to the user (luckily no large projects seem to do this). This is probably because [our first example of setting up OpenPGP.js](https://github.com/openpgpjs/openpgpjs#set-up) includes it (which is modified now).

  

Therefore, we have decided to maintain support for the previous version, and only enable support for the new version when setting `aead_protect_version = 4`.


AEAD Support Feature Flags
--------------------------

  

The new draft adds feature flags for AEAD support in public keys. We add those flags when support for the new draft is enabled. When encrypting using a public key, we only use AEAD when the target key claims support for it. (This only applies for the new draft — the old draft didn't support feature flags so we don't look for them.)

  

Preferred AEAD Algorithms
-------------------------

  

The new draft also adds a packet containing the AEAD algorithms that the user of the public key prefers. When encrypting using a public key, those preferences have precedence over the `aead_mode` setting. When generating a public key, we claim preference for EAX over OCB, since EAX is for a large part implemented using native crypto.

  

The `aead_mode` setting currently does not influence the generated preferences, causing it to have no effect when solely using public-key cryptography. This restriction also applies to the other algorithm options (`prefer_hash_algorithm`, `encryption_cipher` and `compression`) and could be fixed together with those in the future.

Version 5 Keys
------
The draft also specifies V5 Public/Private Key packets and V5 Symmetric-Key Encrypted Session Key packets. The main difference with their V4 counterparts is that they encrypt their contents with an AEAD algorithm. We generate these V5 packets when support for this draft version is enabled.

V5 Public/Private Keys also have some other minor improvements. As per the spec:

> The version 5 format is similar to the version 4 format except for the addition of a count for the key material.  This count helps parsing secret key packets (which are an extension of the public key packet format) in the case of an unknown algoritm.  In addition, fingerprints of version 5 keys are calculated differently from version 4 keys. 

